### PR TITLE
Uploading coverage reports to codecov

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,4 +32,6 @@ jobs:
       run: pytest --pyargs hermes_core --cov hermes_core
       env:
         PLATFORM: ${{ matrix.platform }}
+    - name: Upload coverage reports to Codecov with GitHub Action
+      uses: codecov/codecov-action@v3
 


### PR DESCRIPTION
This addresses issue #15 and makes use of [codecov](http://codecov.io). This app has also been installed this organization which is required for this to work.