### PR TITLE
Using f-strings and log on import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ hermes_core/version.py
 
 # Mac hidden files
 .DS_Store
+
+# docs/api
+docs/api

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "esbonio.server.enabled": true
+    "esbonio.server.enabled": true,
+    "python.formatting.blackPath": "/usr/local/bin/black"
 }

--- a/docs/dev-guide/code_standards.rst
+++ b/docs/dev-guide/code_standards.rst
@@ -16,7 +16,7 @@ Language Standard
 * All code must be compatible with Python 3.7 and later.
 
 * The new Python 3 formatting style should be used (i.e.
-  ``"{0:s}".format("spam")`` instead of ``"%s" % "spam"``).
+  ``f"{spam:s}"`` instead of ``"%s" % "spam"``).
 
 Coding Style/Conventions
 ========================

--- a/hermes_core/__init__.py
+++ b/hermes_core/__init__.py
@@ -20,4 +20,6 @@ __all__ = ["config", "print_config"]
 MISSION_NAME = "hermes"
 INST_NAMES = ["eea", "nemisis", "merit", "spani"]
 INST_SHORTNAMES = ["eea", "nms", "mrt", "spn"]
+INST_TARGETNAMES = ["EEA", "MAG", "MRT", "SPANI"]
 INST_TO_SHORTNAME = dict(zip(INST_NAMES, INST_SHORTNAMES))
+INST_TO_TARGETNAME = dict(zip(INST_NAMES, INST_TARGETNAMES))

--- a/hermes_core/__init__.py
+++ b/hermes_core/__init__.py
@@ -24,4 +24,4 @@ INST_TARGETNAMES = ["EEA", "MAG", "MRT", "SPANI"]
 INST_TO_SHORTNAME = dict(zip(INST_NAMES, INST_SHORTNAMES))
 INST_TO_TARGETNAME = dict(zip(INST_NAMES, INST_TARGETNAMES))
 
-log.info("hermes_core version: {}".format(__version__))
+log.info(f"hermes_core version: {__version__}")

--- a/hermes_core/__init__.py
+++ b/hermes_core/__init__.py
@@ -23,3 +23,5 @@ INST_SHORTNAMES = ["eea", "nms", "mrt", "spn"]
 INST_TARGETNAMES = ["EEA", "MAG", "MRT", "SPANI"]
 INST_TO_SHORTNAME = dict(zip(INST_NAMES, INST_SHORTNAMES))
 INST_TO_TARGETNAME = dict(zip(INST_NAMES, INST_TARGETNAMES))
+
+log.info("hermes_core version: {}".format(__version__))

--- a/hermes_core/__init__.py
+++ b/hermes_core/__init__.py
@@ -23,3 +23,5 @@ INST_SHORTNAMES = ["eea", "nms", "mrt", "spn"]
 INST_TARGETNAMES = ["EEA", "MAG", "MERIT", "SPANI"]
 INST_TO_SHORTNAME = dict(zip(INST_NAMES, INST_SHORTNAMES))
 INST_TO_TARGETNAME = dict(zip(INST_NAMES, INST_TARGETNAMES))
+
+log.info(f"hermes_core version: {__version__}")

--- a/hermes_core/tests/test_util_util.py
+++ b/hermes_core/tests/test_util_util.py
@@ -7,13 +7,14 @@ from hermes_core.util import util
 time = "2024-04-06T12:06:21"
 time_formatted = "20240406_120621"
 
+
 # fmt: off
 @pytest.mark.parametrize("instrument,time,level,version,result", [
-        ("eea", time, "l1", "1.2.3", f"hermes_eea_l1_{time_formatted}_v1.2.3.cdf"),
-        ("merit", time, "l2", "2.4.5", f"hermes_mrt_l2_{time_formatted}_v2.4.5.cdf"),
-        ("nemisis", time, "l2", "1.3.5", f"hermes_nms_l2_{time_formatted}_v1.3.5.cdf"),
-        ("spani", time, "l3", "2.4.5", f"hermes_spn_l3_{time_formatted}_v2.4.5.cdf"),
-    ],
+    ("eea", time, "l1", "1.2.3", f"hermes_eea_l1_{time_formatted}_v1.2.3.cdf"),
+    ("merit", time, "l2", "2.4.5", f"hermes_mrt_l2_{time_formatted}_v2.4.5.cdf"),
+    ("nemisis", time, "l2", "1.3.5", f"hermes_nms_l2_{time_formatted}_v1.3.5.cdf"),
+    ("spani", time, "l3", "2.4.5", f"hermes_spn_l3_{time_formatted}_v2.4.5.cdf"),
+]
 )
 def test_science_filename_output_a(instrument, time, level, version, result):
     """Test simple cases with expected output"""
@@ -28,43 +29,58 @@ def test_science_filename_output_b():
     """Test more complex cases of expected output"""
 
     # mode
-    assert util.create_science_filename(
-        "spani", time, level="l3", mode="2s", version="2.4.5"
-    ) == f"hermes_spn_2s_l3_{time_formatted}_v2.4.5.cdf"
+    assert (
+        util.create_science_filename(
+            "spani", time, level="l3", mode="2s", version="2.4.5"
+        )
+        == f"hermes_spn_2s_l3_{time_formatted}_v2.4.5.cdf"
+    )
     # test
-    assert util.create_science_filename(
-        "spani", time, level="l1", version="2.4.5", test=True
-    ) == f"hermes_spn_l1test_{time_formatted}_v2.4.5.cdf"
+    assert (
+        util.create_science_filename(
+            "spani", time, level="l1", version="2.4.5", test=True
+        )
+        == f"hermes_spn_l1test_{time_formatted}_v2.4.5.cdf"
+    )
     # all options
-    assert util.create_science_filename(
-        "spani",
-        time,
-        level="l3",
-        mode="2s",
-        descriptor="burst",
-        version="2.4.5",
-        test=True,
-    ) == f"hermes_spn_2s_l3test_burst_{time_formatted}_v2.4.5.cdf"
+    assert (
+        util.create_science_filename(
+            "spani",
+            time,
+            level="l3",
+            mode="2s",
+            descriptor="burst",
+            version="2.4.5",
+            test=True,
+        )
+        == f"hermes_spn_2s_l3test_burst_{time_formatted}_v2.4.5.cdf"
+    )
     # Time object instead of str
-    assert util.create_science_filename(
-        "spani",
-        Time(time),
-        level="l3",
-        mode="2s",
-        descriptor="burst",
-        version="2.4.5",
-        test=True,
-    ) == f"hermes_spn_2s_l3test_burst_{time_formatted}_v2.4.5.cdf"
+    assert (
+        util.create_science_filename(
+            "spani",
+            Time(time),
+            level="l3",
+            mode="2s",
+            descriptor="burst",
+            version="2.4.5",
+            test=True,
+        )
+        == f"hermes_spn_2s_l3test_burst_{time_formatted}_v2.4.5.cdf"
+    )
     # Time object but created differently
-    assert util.create_science_filename(
-        "spani",
-        Time(2460407.004409722, format="jd"),
-        level="l3",
-        mode="2s",
-        descriptor="burst",
-        version="2.4.5",
-        test=True,
-    ) == f"hermes_spn_2s_l3test_burst_{time_formatted}_v2.4.5.cdf"
+    assert (
+        util.create_science_filename(
+            "spani",
+            Time(2460407.004409722, format="jd"),
+            level="l3",
+            mode="2s",
+            descriptor="burst",
+            version="2.4.5",
+            test=True,
+        )
+        == f"hermes_spn_2s_l3test_burst_{time_formatted}_v2.4.5.cdf"
+    )
 
 
 def test_parse_science_filename_output():

--- a/hermes_core/tests/test_util_util.py
+++ b/hermes_core/tests/test_util_util.py
@@ -4,35 +4,37 @@ import pytest
 from astropy.time import Time
 from hermes_core.util import util
 
+time = "2024-04-06T12:06:21"
+time_formatted = "20240406_120621"
 
-def test_science_filename_output():
-    """Test expected output"""
-    time = "2024-04-06T12:06:21"
-    time_formatted = "20240406_120621"
+# fmt: off
+@pytest.mark.parametrize("instrument,time,level,version,result", [
+        ("eea", time, "l1", "1.2.3", "hermes_eea_l1_{}_v1.2.3.cdf".format(time_formatted)),
+        ("merit", time, "l2", "2.4.5", "hermes_mrt_l2_{}_v2.4.5.cdf".format(time_formatted)),
+        ("nemisis", time, "l2", "1.3.5", "hermes_nms_l2_{}_v1.3.5.cdf".format(time_formatted)),
+        ("spani", time, "l3", "2.4.5", "hermes_spn_l3_{}_v2.4.5.cdf".format(time_formatted)),
+    ],
+)
+def test_science_filename_output_a(instrument, time, level, version, result):
+    """Test simple cases with expected output"""
+    assert (
+        util.create_science_filename(instrument, time, level=level, version=version)
+        == result
+    )
+# fmt: on
 
-    assert util.create_science_filename(
-        "eea", time, level="l0", version="1.2.3"
-    ) == "hermes_eea_l0_{}_v1.2.3".format(time_formatted)
-    # merit
-    assert util.create_science_filename(
-        "merit", time, level="l2", version="2.4.5"
-    ) == "hermes_mrt_l2_{}_v2.4.5".format(time_formatted)
-    # nemisis and version
-    assert util.create_science_filename(
-        "nemisis", time, level="l2", version="1.3.5"
-    ) == "hermes_nms_l2_{}_v1.3.5".format(time_formatted)
-    # spani and level
-    assert util.create_science_filename(
-        "spani", time, level="l3", version="2.4.5"
-    ) == "hermes_spn_l3_{}_v2.4.5".format(time_formatted)
+
+def test_science_filename_output_b():
+    """Test more complex cases of expected output"""
+
     # mode
     assert util.create_science_filename(
         "spani", time, level="l3", mode="2s", version="2.4.5"
-    ) == "hermes_spn_2s_l3_{}_v2.4.5".format(time_formatted)
+    ) == "hermes_spn_2s_l3_{}_v2.4.5.cdf".format(time_formatted)
     # test
     assert util.create_science_filename(
-        "spani", time, level="l0", version="2.4.5", test=True
-    ) == "hermes_spn_l0test_{}_v2.4.5".format(time_formatted)
+        "spani", time, level="l1", version="2.4.5", test=True
+    ) == "hermes_spn_l1test_{}_v2.4.5.cdf".format(time_formatted)
     # all options
     assert util.create_science_filename(
         "spani",
@@ -42,7 +44,7 @@ def test_science_filename_output():
         descriptor="burst",
         version="2.4.5",
         test=True,
-    ) == "hermes_spn_2s_l3test_burst_{}_v2.4.5".format(time_formatted)
+    ) == "hermes_spn_2s_l3test_burst_{}_v2.4.5.cdf".format(time_formatted)
     # Time object instead of str
     assert util.create_science_filename(
         "spani",
@@ -52,7 +54,7 @@ def test_science_filename_output():
         descriptor="burst",
         version="2.4.5",
         test=True,
-    ) == "hermes_spn_2s_l3test_burst_{}_v2.4.5".format(time_formatted)
+    ) == "hermes_spn_2s_l3test_burst_{}_v2.4.5.cdf".format(time_formatted)
     # Time object but created differently
     assert util.create_science_filename(
         "spani",
@@ -62,81 +64,7 @@ def test_science_filename_output():
         descriptor="burst",
         version="2.4.5",
         test=True,
-    ) == "hermes_spn_2s_l3test_burst_{}_v2.4.5".format(time_formatted)
-
-
-def test_science_filename_exceptions():
-    """Test for errors"""
-    good_time = "2025-06-02T12:04:01"
-    good_instrument = "eea"
-    good_level = "l0"
-    good_version = "1.3.4"
-    with pytest.raises(ValueError):
-        # not enough depth to version number
-        util.create_science_filename(
-            good_instrument, good_time, level=good_level, version="1.3"
-        )
-        util.create_science_filename(
-            good_instrument, good_time, level=good_level, version="1"
-        )
-        util.create_science_filename(
-            good_instrument, good_time, level=good_level, version="1.5.6.7"
-        )
-        util.create_science_filename(
-            good_instrument, good_time, level=good_level, version="1.."
-        )
-        # a letter in version number
-        util.create_science_filename(
-            good_instrument, good_time, level=good_level, version="a.5.6"
-        )
-
-        # wrong level specification
-        util.create_science_filename(
-            good_instrument, good_time, level="la", version=good_version
-        )
-        util.create_science_filename(
-            good_instrument, good_time, level="squirrel", version=good_version
-        )
-
-        # wrong instrument name
-        util.create_science_filename(
-            "eeb", good_time, level=good_level, version=good_version
-        )
-        util.create_science_filename(
-            "fpi", good_time, level=good_level, version=good_version
-        )
-        util.create_science_filename(
-            "potato", good_time, level=good_level, version=good_version
-        )
-
-        # bad time string
-        # non-existent time
-        util.create_science_filename(
-            good_instrument,
-            "2023-13-04T12:06:21",
-            level=good_level,
-            version=good_version,
-        )
-        # not isot format
-        util.create_science_filename(
-            "eeb", "2023/13/04 12:06:21", level=good_level, version=good_version
-        )
-        # not valid input for time
-        util.create_science_filename(
-            "eeb", time=12345345, level=good_level, version=good_version
-        )
-        # _ character in mode
-        util.create_science_filename(
-            "eeb", time=12345345, level=good_level, version=good_version, mode="o_o"
-        )
-        # _ character in descriptor
-        util.create_science_filename(
-            "eeb",
-            time=12345345,
-            level=good_level,
-            version=good_version,
-            descriptor="blue_green",
-        )
+    ) == "hermes_spn_2s_l3test_burst_{}_v2.4.5.cdf".format(time_formatted)
 
 
 def test_parse_science_filename_output():
@@ -224,8 +152,8 @@ def test_parse_science_filename_output():
     assert util.parse_science_filename(f) == input
 
 
-def test_parse_science_filename_errors():
-    """Test for errors"""
+def test_parse_science_filename_errors_l1():
+    """Test for errors in l1 and above files"""
     with pytest.raises(ValueError):
         # wrong mission name
         f = "veeger_spn_2s_l3test_burst_20240406_120621_v2.4.5"
@@ -234,3 +162,69 @@ def test_parse_science_filename_errors():
         # wrong instrument name
         f = "hermes_www_2s_l3test_burst_20240406_120621_v2.4.5"
         util.parse_science_filename(f)
+
+
+good_time = "2025-06-02T12:04:01"
+good_instrument = "eea"
+good_level = "l1"
+good_version = "1.3.4"
+# fmt: off
+@pytest.mark.parametrize("instrument,time,level,version", [
+    (good_instrument, good_time, good_level, "1.3"), # bad version specifications
+    (good_instrument, good_time, good_level, "1"),
+    (good_instrument, good_time, good_level, "1.5.6.7"),
+    (good_instrument, good_time, good_level, "1.."),
+    (good_instrument, good_time, good_level, "a.5.6"),
+    (good_instrument, good_time, "la", good_version),  # wrong level specifications
+    (good_instrument, good_time, "squirrel", good_version),
+    (good_instrument, good_time, "l0", good_version),
+    ("potato", good_time, good_level, good_version),  # wrong instrument names
+    ("eeb", good_time, good_level, good_version),
+    ("fpi", good_time, good_level, good_version),
+    (good_instrument, "2023-13-04T12:06:21", good_level, good_version),  # non-existent time
+    (good_instrument, "2023/13/04 12:06:21", good_level, good_version),  # not isot format
+    (good_instrument, "2023/13/04 12:06:21", good_level, good_version),  # not isot format
+    (good_instrument, "12345345", good_level, good_version),  # not valid input for time
+    ]
+)
+def test_science_filename_errors_l1_a(instrument, time, level, version):
+    """"""
+    with pytest.raises(ValueError) as e:
+        util.create_science_filename(
+            instrument, time, level=level, version=version
+        )
+# fmt: on
+
+
+def test_science_filename_errors_l1_b():
+    with pytest.raises(ValueError):
+        # _ character in mode
+        util.create_science_filename(
+            "eeb", time="12345345", level=good_level, version=good_version, mode="o_o"
+        )
+    with pytest.raises(ValueError):
+        # _ character in descriptor
+        util.create_science_filename(
+            "eeb",
+            time="12345345",
+            level=good_level,
+            version=good_version,
+            descriptor="blue_green",
+        )
+
+
+# fmt: off
+@pytest.mark.parametrize("filename,instrument,time,level,version", [
+    ("hermes_MAG_l0_2024094-124603_v01.bin", "nemisis", "2024-04-03T12:46:03", "l0", "01"),
+    ("hermes_EEA_l0_2026337-124603_v11.bin", "eea", "2026-12-03T12:46:03", "l0", "11"),
+    ("hermes_MRT_l0_2026215-124603_v21.bin", "merit", "2026-08-03T12:46:03", "l0", "21"),
+    ("hermes_SPANI_l0_2026337-065422_v11.bin", "spani", "2026-12-03T06:54:22", "l0", "11"),
+])
+def test_parse_l0_filenames(filename, instrument, time, level, version):
+    """Testing parsing of MOC-generated level 0 files."""
+    result = util.parse_science_filename(filename)
+    assert result['instrument'] == instrument
+    assert result['level'] == level
+    assert result['version'] == version
+    assert result['time'] == Time(time)
+# fmt: on

--- a/hermes_core/tests/test_util_util.py
+++ b/hermes_core/tests/test_util_util.py
@@ -9,10 +9,10 @@ time_formatted = "20240406_120621"
 
 # fmt: off
 @pytest.mark.parametrize("instrument,time,level,version,result", [
-        ("eea", time, "l1", "1.2.3", "hermes_eea_l1_{}_v1.2.3.cdf".format(time_formatted)),
-        ("merit", time, "l2", "2.4.5", "hermes_mrt_l2_{}_v2.4.5.cdf".format(time_formatted)),
-        ("nemisis", time, "l2", "1.3.5", "hermes_nms_l2_{}_v1.3.5.cdf".format(time_formatted)),
-        ("spani", time, "l3", "2.4.5", "hermes_spn_l3_{}_v2.4.5.cdf".format(time_formatted)),
+        ("eea", time, "l1", "1.2.3", f"hermes_eea_l1_{time_formatted}_v1.2.3.cdf"),
+        ("merit", time, "l2", "2.4.5", f"hermes_mrt_l2_{time_formatted}_v2.4.5.cdf"),
+        ("nemisis", time, "l2", "1.3.5", f"hermes_nms_l2_{time_formatted}_v1.3.5.cdf"),
+        ("spani", time, "l3", "2.4.5", f"hermes_spn_l3_{time_formatted}_v2.4.5.cdf"),
     ],
 )
 def test_science_filename_output_a(instrument, time, level, version, result):
@@ -30,11 +30,11 @@ def test_science_filename_output_b():
     # mode
     assert util.create_science_filename(
         "spani", time, level="l3", mode="2s", version="2.4.5"
-    ) == "hermes_spn_2s_l3_{}_v2.4.5.cdf".format(time_formatted)
+    ) == f"hermes_spn_2s_l3_{time_formatted}_v2.4.5.cdf"
     # test
     assert util.create_science_filename(
         "spani", time, level="l1", version="2.4.5", test=True
-    ) == "hermes_spn_l1test_{}_v2.4.5.cdf".format(time_formatted)
+    ) == f"hermes_spn_l1test_{time_formatted}_v2.4.5.cdf"
     # all options
     assert util.create_science_filename(
         "spani",
@@ -44,7 +44,7 @@ def test_science_filename_output_b():
         descriptor="burst",
         version="2.4.5",
         test=True,
-    ) == "hermes_spn_2s_l3test_burst_{}_v2.4.5.cdf".format(time_formatted)
+    ) == f"hermes_spn_2s_l3test_burst_{time_formatted}_v2.4.5.cdf"
     # Time object instead of str
     assert util.create_science_filename(
         "spani",
@@ -54,7 +54,7 @@ def test_science_filename_output_b():
         descriptor="burst",
         version="2.4.5",
         test=True,
-    ) == "hermes_spn_2s_l3test_burst_{}_v2.4.5.cdf".format(time_formatted)
+    ) == f"hermes_spn_2s_l3test_burst_{time_formatted}_v2.4.5.cdf"
     # Time object but created differently
     assert util.create_science_filename(
         "spani",
@@ -64,7 +64,7 @@ def test_science_filename_output_b():
         descriptor="burst",
         version="2.4.5",
         test=True,
-    ) == "hermes_spn_2s_l3test_burst_{}_v2.4.5.cdf".format(time_formatted)
+    ) == f"hermes_spn_2s_l3test_burst_{time_formatted}_v2.4.5.cdf"
 
 
 def test_parse_science_filename_output():

--- a/hermes_core/util/config.py
+++ b/hermes_core/util/config.py
@@ -134,7 +134,7 @@ def print_config():
     for section in hermes_core.config.sections():
         print(f"  [{section}]")
         for option in hermes_core.config.options(section):
-            print("  {} = {}".format(option, hermes_core.config.get(section, option)))
+            print(f"  {option} = {hermes_core.config.get(section, option)}")
         print("")
 
 

--- a/hermes_core/util/util.py
+++ b/hermes_core/util/util.py
@@ -13,6 +13,7 @@ __all__ = ["create_science_filename"]
 TIME_FORMAT_L0 = "%Y%j-%H%M%S"
 TIME_FORMAT = "%Y%m%d_%H%M%S"
 VALID_DATA_LEVELS = ["l0", "l1", "ql", "l2", "l3", "l4"]
+FILENAME_EXTENSION = ".cdf"
 
 
 def create_science_filename(
@@ -50,7 +51,8 @@ def create_science_filename(
 
     if instrument not in hermes_core.INST_NAMES:
         raise ValueError(
-            f"Instrument, {instrument}, is not recognized. Must be one of {hermes_core.INST_NAMES}.")
+            f"Instrument, {instrument}, is not recognized. Must be one of {hermes_core.INST_NAMES}."
+        )
     if level not in VALID_DATA_LEVELS[1:]:
         raise ValueError(
             f"Level, {level}, is not recognized. Must be one of {VALID_DATA_LEVELS[1:]}."
@@ -112,9 +114,7 @@ def parse_science_filename(filename):
     filename_components = file_name.split("_")
 
     if filename_components[0] != hermes_core.MISSION_NAME:
-        raise ValueError(
-            f"File {filename} not recognized. Not a valid mission name."
-        )
+        raise ValueError(f"File {filename} not recognized. Not a valid mission name.")
 
     if file_ext == ".bin":
         if filename_components[1] not in hermes_core.INST_TARGETNAMES:

--- a/hermes_core/util/util.py
+++ b/hermes_core/util/util.py
@@ -50,29 +50,22 @@ def create_science_filename(
 
     if instrument not in hermes_core.INST_NAMES:
         raise ValueError(
-            "Instrument, {inst}, is not recognized. Must be one of {valid}.".format(
-                inst=instrument, valid=hermes_core.INST_NAMES
-            )
-        )
+            f"Instrument, {instrument}, is not recognized. Must be one of {hermes_core.INST_NAMES}.")
     if level not in VALID_DATA_LEVELS[1:]:
         raise ValueError(
-            "Level, {level}, is not recognized. Must be one of {valid}.".format(
-                level=level, valid=VALID_DATA_LEVELS[1:]
-            )
+            f"Level, {level}, is not recognized. Must be one of {VALID_DATA_LEVELS[1:]}."
         )
     # check that version is in the right format with three parts
     if len(version.split(".")) != 3:
         raise ValueError(
-            "Version, {version}, is not formatted correctly. Should be X.Y.Z".format(
-                version=version
-            )
+            f"Version, {version}, is not formatted correctly. Should be X.Y.Z"
         )
     # check that version has integers in each part
     for item in version.split("."):
         try:
             int_value = int(item)
         except ValueError:
-            raise ValueError("Version, {version}, is not all integers.")
+            raise ValueError(f"Version, {version}, is not all integers.")
 
     if test is True:
         test_str = "test"
@@ -83,15 +76,7 @@ def create_science_filename(
             "The underscore symbol _ is not allowed in mode or descriptor."
         )
 
-    filename = "hermes_{inst}_{mode}_{level}{test}_{descriptor}_{time}_v{version}".format(
-        inst=hermes_core.INST_TO_SHORTNAME[instrument],
-        mode=mode,
-        level=level,
-        test=test_str,
-        descriptor=descriptor,
-        time=time_str,
-        version=version,
-    )
+    filename = f"hermes_{hermes_core.INST_TO_SHORTNAME[instrument]}_{mode}_{level}{test_str}_{descriptor}_{time_str}_v{version}"
     filename = filename.replace("__", "_")  # reformat if mode or descriptor not given
 
     return filename + ".cdf"
@@ -128,19 +113,17 @@ def parse_science_filename(filename):
 
     if filename_components[0] != hermes_core.MISSION_NAME:
         raise ValueError(
-            "File {} not recognized. Not a valid mission name.".format(filename)
+            f"File {filename} not recognized. Not a valid mission name."
         )
 
     if file_ext == ".bin":
         if filename_components[1] not in hermes_core.INST_TARGETNAMES:
             raise ValueError(
-                "File {} not recognized. Not a valid target name.".format(filename)
+                f"File {filename} not recognized. Not a valid target name."
             )
         if filename_components[2] != VALID_DATA_LEVELS[0]:
             raise ValueError(
-                "Data level {} is not correct for this file extension.".format(
-                    filename_components[2]
-                )
+                f"Data level {filename_components[2]} is not correct for this file extension."
             )
         else:
             result["level"] = filename_components[2]
@@ -152,7 +135,7 @@ def parse_science_filename(filename):
     elif file_ext == ".cdf":
         if filename_components[1] not in hermes_core.INST_SHORTNAMES:
             raise ValueError(
-                "File {} not recognized. Not a valid instrument name.".format(filename)
+                "File {filename} not recognized. Not a valid instrument name."
             )
 
         #  reverse the dictionary to look up instrument name from the short name
@@ -178,7 +161,7 @@ def parse_science_filename(filename):
             if len(filename_components) == 7:
                 result["descriptor"] = filename_components[3]
     else:
-        raise ValueError("File extension {} not recognized.".format(file_ext))
+        raise ValueError(f"File extension {file_ext} not recognized.")
 
     result["instrument"] = from_shortname[filename_components[1]]
     result["version"] = filename_components[-1][1:]  # remove the v

--- a/hermes_core/util/util.py
+++ b/hermes_core/util/util.py
@@ -13,6 +13,7 @@ __all__ = ["create_science_filename"]
 TIME_FORMAT_L0 = "%Y%j-%H%M%S"
 TIME_FORMAT = "%Y%m%d_%H%M%S"
 VALID_DATA_LEVELS = ["l0", "l1", "ql", "l2", "l3", "l4"]
+FILENAME_EXTENSION = ".cdf"
 
 
 def create_science_filename(
@@ -79,7 +80,7 @@ def create_science_filename(
     filename = f"hermes_{hermes_core.INST_TO_SHORTNAME[instrument]}_{mode}_{level}{test_str}_{descriptor}_{time_str}_v{version}"
     filename = filename.replace("__", "_")  # reformat if mode or descriptor not given
 
-    return filename + ".cdf"
+    return filename + FILENAME_EXTENSION
 
 
 def parse_science_filename(filename):


### PR DESCRIPTION
This cleans up the code to use fstrings instead of the format syntax. fstrings make the code much cleaner. Also updated the code standards to say to use fstrings.

This also adds a log message on import to show the version number of the package on import. Useful for debugging purposes.

Addresses issues #27, #23.