### PR TITLE
Fix devcontainer config to use new vscode user

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -46,7 +46,7 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Hermes_core package is uninstalled from the container image after it is created to avoid circular import errors during development 
-	"postCreateCommand": "pip3 uninstall hermes_core -y",
+	"postCreateCommand": "sudo pip3 uninstall hermes_core -y",
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 		"python.languageServer": "Pylance",
 		"python.linting.enabled": true,
 		"python.linting.pylintEnabled": true,
-		"python.formatting.blackPath": "/home/vscode/.local/bin/black",
+		"python.formatting.blackPath": "/usr/local/bin/black",
 		"python.formatting.provider": "black",
 		"python.formatting.blackArgs": [
 			"--line-length",
@@ -22,11 +22,11 @@
 		"python.linting.lintOnSave": true,
 		"python.linting.flake8Enabled": true,
 		"editor.formatOnSave": true,
-		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
-		"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
-		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
-		"python.linting.pycodestylePath": "/home/vscode/.local/bin/pycodestyle",
-		"python.linting.pydocstylePath": "/home/vscode/.local/bin/pydocstyle",
+		"python.linting.banditPath": "/usr/local/bin/bandit",
+		"python.linting.flake8Path": "/usr/local/bin/flake8",
+		"python.linting.mypyPath": "/usr/local/bin/mypy",
+		"python.linting.pycodestylePath": "/usr/local/bin/pycodestyle",
+		"python.linting.pydocstylePath": "/usr/local/bin/pydocstyle",
 		"python.linting.pylintPath": "/usr/bin/pylint",
 		"terminal.integrated.profiles.linux": {
 			"bash (login)": {
@@ -46,7 +46,7 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Hermes_core package is uninstalled from the container image after it is created to avoid circular import errors during development 
-	"postCreateCommand": "pip3 uninstall hermes_core -y"
+	"postCreateCommand": "pip3 uninstall hermes_core -y",
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	// "remoteUser": "vscode"
+	"remoteUser": "vscode"
 }


### PR DESCRIPTION
This PR (will be very similar to the other 4), it helps address this issue: https://github.com/HERMES-SOC/hermes_eea/issues/6

It sets the default user of the devcontainer to be the new `vscode` user that is introduced in this PR (Should be merged after this one is merged): https://github.com/HERMES-SOC/sdc_aws_base_docker_image/pull/23

It also fixes a few path issues that were pointed out in the issue.