### PR TITLE
Add support for `mode` on `l0` files + support old formats

### DIFF
--- a/hermes_core/tests/test_util_util.py
+++ b/hermes_core/tests/test_util_util.py
@@ -234,17 +234,20 @@ def test_science_filename_errors_l1_b():
 
 
 # fmt: off
-@pytest.mark.parametrize("filename,instrument,time,level,version", [
-    ("hermes_MAG_l0_2024094-124603_v01.bin", "nemisis", "2024-04-03T12:46:03", "l0", "01"),
-    ("hermes_EEA_l0_2026337-124603_v11.bin", "eea", "2026-12-03T12:46:03", "l0", "11"),
-    ("hermes_MERIT_l0_2026215-124603_v21.bin", "merit", "2026-08-03T12:46:03", "l0", "21"),
-    ("hermes_SPANI_l0_2026337-065422_v11.bin", "spani", "2026-12-03T06:54:22", "l0", "11"),
+@pytest.mark.parametrize("filename,instrument,time,level,version,mode", [
+    ("hermes_MAG_l0_2024094-124603_v01.bin", "nemisis", "2024-04-03T12:46:03", "l0", "01", None),
+    ("hermes_EEA_l0_2026337-124603_v11.bin", "eea", "2026-12-03T12:46:03", "l0", "11", None),
+    ("hermes_MERIT_l0_2026215-124603_v21.bin", "merit", "2026-08-03T12:46:03", "l0", "21", None),
+    ("hermes_SPANI_l0_2026337-065422_v11.bin", "spani", "2026-12-03T06:54:22", "l0", "11", None),
+    ("hermes_MERIT_VC_l0_2026215-124603_v21.bin", "merit", "2026-08-03T12:46:03", "l0", "21", "VC"),
+    ("hermes_SPANI_VA_l0_2026215-124603_v21.bin", "spani", "2026-08-03T12:46:03", "l0", "21", "VA")
 ])
-def test_parse_l0_filenames(filename, instrument, time, level, version):
+def test_parse_l0_filenames(filename, instrument, time, level, version, mode):
     """Testing parsing of MOC-generated level 0 files."""
     result = util.parse_science_filename(filename)
     assert result['instrument'] == instrument
     assert result['level'] == level
     assert result['version'] == version
     assert result['time'] == Time(time)
+    assert result['mode'] == mode
 # fmt: on

--- a/hermes_core/util/util.py
+++ b/hermes_core/util/util.py
@@ -122,16 +122,22 @@ def parse_science_filename(filepath):
             raise ValueError(
                 f"File {filename} not recognized. Not a valid target name."
             )
-        if filename_components[2] != VALID_DATA_LEVELS[0]:
+
+        offset = 1 if len(filename_components) > 5 else 0
+
+        if offset:
+            result["mode"] = filename_components[2]
+
+        if filename_components[2 + offset] != VALID_DATA_LEVELS[0]:
             raise ValueError(
-                f"Data level {filename_components[2]} is not correct for this file extension."
+                f"Data level {filename_components[2 + offset]} is not correct for this file extension."
             )
         else:
-            result["level"] = filename_components[2]
+            result["level"] = filename_components[2 + offset]
         #  reverse the dictionary to look up instrument name from the short name
         from_shortname = {v: k for k, v in hermes_core.INST_TO_TARGETNAME.items()}
 
-        result["time"] = Time.strptime(filename_components[3], TIME_FORMAT_L0)
+        result["time"] = Time.strptime(filename_components[3 + offset], TIME_FORMAT_L0)
 
     elif file_ext == ".cdf":
         if filename_components[1] not in hermes_core.INST_SHORTNAMES:


### PR DESCRIPTION
Fixes an issue with parsing new MERIT binary filenames, which includes mode. This small PR adds some tests and support for the new filename format which includes the mode, along with maintaining former filename compatibility if no mode is provided.

Closes: https://github.com/HERMES-SOC/hermes_core/issues/49