### PR TITLE
Update to use Development image of base container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,8 +3,11 @@
 {
 	"name": "Ubuntu 20.04 Python 3",
 	// Repo where this image's Dockerfile is maintained: https://github.com/HERMES-SOC/docker-lambda-base
-	"image": "public.ecr.aws/w5r9l1c8/swsoc-docker-lambda-base:latest",
-	"initializeCommand": "docker logout public.ecr.aws && docker pull public.ecr.aws/w5r9l1c8/swsoc-docker-lambda-base:latest",
+	"image": "public.ecr.aws/w5r9l1c8/dev-swsoc-docker-lambda-base:latest",
+	"initializeCommand": "docker logout public.ecr.aws && docker pull public.ecr.aws/w5r9l1c8/dev-swsoc-docker-lambda-base:latest",
+	// If you want to run the production version of the container, comment out the image and initializeCommand lines above and uncomment the line below.
+	// "image": "public.ecr.aws/w5r9l1c8/dev-swsoc-docker-lambda-base:latest",
+	// "initializeCommand": "docker logout public.ecr.aws && docker pull public.ecr.aws/w5r9l1c8/dev-swsoc-docker-lambda-base:latest",
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"python.pythonPath": "/usr/bin/python3",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,8 +6,8 @@
 	"image": "public.ecr.aws/w5r9l1c8/dev-swsoc-docker-lambda-base:latest",
 	"initializeCommand": "docker logout public.ecr.aws && docker pull public.ecr.aws/w5r9l1c8/dev-swsoc-docker-lambda-base:latest",
 	// If you want to run the production version of the container, comment out the image and initializeCommand lines above and uncomment the line below.
-	// "image": "public.ecr.aws/w5r9l1c8/dev-swsoc-docker-lambda-base:latest",
-	// "initializeCommand": "docker logout public.ecr.aws && docker pull public.ecr.aws/w5r9l1c8/dev-swsoc-docker-lambda-base:latest",
+	// "image": "public.ecr.aws/w5r9l1c8/swsoc-docker-lambda-base:latest",
+	// "initializeCommand": "docker logout public.ecr.aws && docker pull public.ecr.aws/w5r9l1c8/swsoc-docker-lambda-base:latest",
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"python.pythonPath": "/usr/bin/python3",

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: public.ecr.aws/w5r9l1c8/swsoc-docker-lambda-base:latest
+      image: public.ecr.aws/w5r9l1c8/dev-swsoc-docker-lambda-base:latest
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
We need to merge this one first: https://github.com/HERMES-SOC/sdc_aws_base_docker_image/pull/37
Description:
Update the `.devcontainer` to use the development base image as well as the docs workflow