### PR TITLE
Change HERMES Time format to ISO format

### DIFF
--- a/docs/user-guide/cdf_format_guide.rst
+++ b/docs/user-guide/cdf_format_guide.rst
@@ -134,8 +134,8 @@ Section 4 of this document.
      - This is an optional field that may not be needed for all products. Where it is used, identifier should be short (e.q. 3-8 characters) descriptors that are helpful to end-users. If a descriptor contains multiple components, underscores are used to separate those components.
      - An optional time span may be specified as "2s" to represent a data file that spans two seconds. In this case, "10s" and "5m" are other expected values that correspond with ten seconds and 5 minutes respectively.
    * - startTime
-     - The start time of the contained data given in "YYYYMMDD_hhmmss"
-     - `20220601_101520`
+     - The start time of the contained data given in `ISO 8601 <https://en.wikipedia.org/wiki/ISO_8601>`_ format.
+     - `2023-05-19T00:00:03.000`
    * - vX.Y.Z
      - The 3-part version number of the data product. Full description of this identifier is provided in Section 3.1.1 of this document.
      - `v0.0.0`, `v<#.#.#>`

--- a/docs/user-guide/cdf_format_guide.rst
+++ b/docs/user-guide/cdf_format_guide.rst
@@ -135,7 +135,7 @@ Section 4 of this document.
      - An optional time span may be specified as "2s" to represent a data file that spans two seconds. In this case, "10s" and "5m" are other expected values that correspond with ten seconds and 5 minutes respectively.
    * - startTime
      - The start time of the contained data given in `ISO 8601 <https://en.wikipedia.org/wiki/ISO_8601>`_ format.
-     - `2023-05-19T00:00:03.000`
+     - `20230519T000003`
    * - vX.Y.Z
      - The 3-part version number of the data product. Full description of this identifier is provided in Section 3.1.1 of this document.
      - `v0.0.0`, `v<#.#.#>`

--- a/hermes_core/tests/test_timedata.py
+++ b/hermes_core/tests/test_timedata.py
@@ -29,7 +29,9 @@ def get_bad_timeseries():
     ts.add_column(col)
 
     # Add Measurement
-    col = Column(data=random(size=(10)), name="measurement", meta={"CATDESC": "Test Measurement"})
+    col = Column(
+        data=random(size=(10)), name="measurement", meta={"CATDESC": "Test Measurement"}
+    )
     ts.add_column(col)
     return ts
 
@@ -212,7 +214,9 @@ def test_timedata_single_measurement():
 
     # Add Measurement
     test_data["test_var1"] = Quantity(value=random(size=(10)), unit="km")
-    test_data["test_var1"].meta.update({"test_attr1": "test_value1", "CATDESC": "Test data"})
+    test_data["test_var1"].meta.update(
+        {"test_attr1": "test_value1", "CATDESC": "Test data"}
+    )
 
     # Convert the Wrapper to a CDF File
     with tempfile.TemporaryDirectory() as tmpdirname:

--- a/hermes_core/tests/test_timedata.py
+++ b/hermes_core/tests/test_timedata.py
@@ -115,7 +115,6 @@ def test_timedata_valid_attrs():
         "Descriptor": "EEA>Electron Electrostatic Analyzer",
         "Data_level": "l1>Level 1",
         "Data_version": "v0.0.1",
-        "Start_time": datetime.datetime.now()
     }
     # fmt: on
 
@@ -431,7 +430,9 @@ def test_timedata_generate_valid_cdf():
 
         # Validate the generated CDF File
         result = validate(filepath=test_file_output_path)
-        assert len(result) <= 1  # TODO Logical Source and File ID Do not Agree
+        assert len(result) <= 2
+        # Logical Source and File ID Do not Agree
+        # ISO Format not Accepted by spacepy.pycdf.istp.FileChecks.times
 
         # Remove the File
         test_file_cache_path = Path(test_file_output_path)
@@ -532,7 +533,9 @@ def test_timedata_from_cdf():
 
         # Validate the generated CDF File
         result = validate(test_file_output_path)
-        assert len(result) <= 1  # TODO Logical Source and File ID Do not Agree
+        assert len(result) <= 2
+        # Logical Source and File ID Do not Agree
+        # ISO Format not Accepted by spacepy.pycdf.istp.FileChecks.times
 
         # Try to Load the CDF File in a new CDFWriter
         new_writer = TimeData.load(test_file_output_path)
@@ -546,7 +549,9 @@ def test_timedata_from_cdf():
 
         # Validate the generated CDF File
         result2 = validate(test_file_output_path2)
-        assert len(result2) <= 1  # TODO Logical Source and File ID Do not Agree
+        assert len(result2) <= 2
+        # Logical Source and File ID Do not Agree
+        # ISO Format not Accepted by spacepy.pycdf.istp.FileChecks.times
         assert len(result) == len(result2)
 
 

--- a/hermes_core/tests/test_timedata.py
+++ b/hermes_core/tests/test_timedata.py
@@ -29,9 +29,7 @@ def get_bad_timeseries():
     ts.add_column(col)
 
     # Add Measurement
-    col = Column(
-        data=random(size=(10)), name="measurement", meta={"CATDESC": "Test Measurement"}
-    )
+    col = Column(data=random(size=(10)), name="measurement", meta={"CATDESC": "Test Measurement"})
     ts.add_column(col)
     return ts
 
@@ -214,9 +212,7 @@ def test_timedata_single_measurement():
 
     # Add Measurement
     test_data["test_var1"] = Quantity(value=random(size=(10)), unit="km")
-    test_data["test_var1"].meta.update(
-        {"test_attr1": "test_value1", "CATDESC": "Test data"}
-    )
+    test_data["test_var1"].meta.update({"test_attr1": "test_value1", "CATDESC": "Test data"})
 
     # Convert the Wrapper to a CDF File
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -430,9 +426,7 @@ def test_timedata_generate_valid_cdf():
 
         # Validate the generated CDF File
         result = validate(filepath=test_file_output_path)
-        assert len(result) <= 2
-        # Logical Source and File ID Do not Agree
-        # ISO Format not Accepted by spacepy.pycdf.istp.FileChecks.times
+        assert len(result) <= 1  # Logical Source and File ID Do not Agree
 
         # Remove the File
         test_file_cache_path = Path(test_file_output_path)
@@ -533,9 +527,7 @@ def test_timedata_from_cdf():
 
         # Validate the generated CDF File
         result = validate(test_file_output_path)
-        assert len(result) <= 2
-        # Logical Source and File ID Do not Agree
-        # ISO Format not Accepted by spacepy.pycdf.istp.FileChecks.times
+        assert len(result) <= 1  # Logical Source and File ID Do not Agree
 
         # Try to Load the CDF File in a new CDFWriter
         new_writer = TimeData.load(test_file_output_path)
@@ -549,9 +541,7 @@ def test_timedata_from_cdf():
 
         # Validate the generated CDF File
         result2 = validate(test_file_output_path2)
-        assert len(result2) <= 2
-        # Logical Source and File ID Do not Agree
-        # ISO Format not Accepted by spacepy.pycdf.istp.FileChecks.times
+        assert len(result2) <= 1  # Logical Source and File ID Do not Agree
         assert len(result) == len(result2)
 
 

--- a/hermes_core/tests/test_util_util.py
+++ b/hermes_core/tests/test_util_util.py
@@ -30,12 +30,16 @@ def test_science_filename_output_b():
 
     # mode
     assert (
-        util.create_science_filename("spani", time, level="l3", mode="2s", version="2.4.5")
+        util.create_science_filename(
+            "spani", time, level="l3", mode="2s", version="2.4.5"
+        )
         == f"hermes_spn_2s_l3_{time_formatted}_v2.4.5.cdf"
     )
     # test
     assert (
-        util.create_science_filename("spani", time, level="l1", version="2.4.5", test=True)
+        util.create_science_filename(
+            "spani", time, level="l1", version="2.4.5", test=True
+        )
         == f"hermes_spn_l1test_{time_formatted}_v2.4.5.cdf"
     )
     # all options

--- a/hermes_core/tests/test_util_util.py
+++ b/hermes_core/tests/test_util_util.py
@@ -5,7 +5,7 @@ from astropy.time import Time
 from hermes_core.util import util
 
 time = "2024-04-06T12:06:21"
-time_formatted = "20240406_120621"
+time_formatted = "2024-04-06T12:06:21.000"
 
 
 # fmt: off

--- a/hermes_core/tests/test_util_util.py
+++ b/hermes_core/tests/test_util_util.py
@@ -5,7 +5,7 @@ from astropy.time import Time
 from hermes_core.util import util
 
 time = "2024-04-06T12:06:21"
-time_formatted = "2024-04-06T12:06:21.000"
+time_formatted = "20240406T120621"
 
 
 # fmt: off
@@ -30,16 +30,12 @@ def test_science_filename_output_b():
 
     # mode
     assert (
-        util.create_science_filename(
-            "spani", time, level="l3", mode="2s", version="2.4.5"
-        )
+        util.create_science_filename("spani", time, level="l3", mode="2s", version="2.4.5")
         == f"hermes_spn_2s_l3_{time_formatted}_v2.4.5.cdf"
     )
     # test
     assert (
-        util.create_science_filename(
-            "spani", time, level="l1", version="2.4.5", test=True
-        )
+        util.create_science_filename("spani", time, level="l1", version="2.4.5", test=True)
         == f"hermes_spn_l1test_{time_formatted}_v2.4.5.cdf"
     )
     # all options

--- a/hermes_core/util/schema.py
+++ b/hermes_core/util/schema.py
@@ -1321,7 +1321,7 @@ class CDFSchema(HERMESDataSchema):
         given in format `YYYYMMDD_hhmmss`
         """
         # Get the Start Time from the TimeSeries
-        return data["time"].to_datetime()[0]
+        return data["time"][0].isot
 
     def _get_version(self, data):
         """

--- a/hermes_core/util/schema.py
+++ b/hermes_core/util/schema.py
@@ -1318,7 +1318,7 @@ class CDFSchema(HERMESDataSchema):
     def _get_start_time(self, data):
         """
         Function to get the start time of the data contained in the CDF
-        given in format `YYYYMMDD_hhmmss`
+        given in format `YYYYMMDDThhmmss`
         """
         # Get the Start Time from the TimeSeries
         return data["time"][0].isot

--- a/hermes_core/util/util.py
+++ b/hermes_core/util/util.py
@@ -11,13 +11,12 @@ import hermes_core
 __all__ = ["create_science_filename", "parse_science_filename", "VALID_DATA_LEVELS"]
 
 TIME_FORMAT_L0 = "%Y%j-%H%M%S"
+TIME_FORMAT = "%Y%m%dT%H%M%S"
 VALID_DATA_LEVELS = ["l0", "l1", "ql", "l2", "l3", "l4"]
 FILENAME_EXTENSION = ".cdf"
 
 
-def create_science_filename(
-    instrument, time, level, version, mode="", descriptor="", test=False
-):
+def create_science_filename(instrument, time, level, version, mode="", descriptor="", test=False):
     """Return a compliant filename. The format is defined as
 
     hermes_{inst}_{mode}_{level}{test}_{descriptor}_{time}_v{version}.cdf
@@ -44,9 +43,9 @@ def create_science_filename(
     test_str = ""
 
     if isinstance(time, str):
-        time_str = Time(time, format="isot").isot
+        time_str = Time(time, format="isot").strftime(TIME_FORMAT)
     else:
-        time_str = time.isot
+        time_str = time.strftime(TIME_FORMAT)
 
     if instrument not in hermes_core.INST_NAMES:
         raise ValueError(
@@ -58,9 +57,7 @@ def create_science_filename(
         )
     # check that version is in the right format with three parts
     if len(version.split(".")) != 3:
-        raise ValueError(
-            f"Version, {version}, is not formatted correctly. Should be X.Y.Z"
-        )
+        raise ValueError(f"Version, {version}, is not formatted correctly. Should be X.Y.Z")
     # check that version has integers in each part
     for item in version.split("."):
         try:
@@ -73,9 +70,7 @@ def create_science_filename(
 
     # the parse_science_filename function depends on _ not being present elsewhere
     if ("_" in mode) or ("_" in descriptor):
-        raise ValueError(
-            "The underscore symbol _ is not allowed in mode or descriptor."
-        )
+        raise ValueError("The underscore symbol _ is not allowed in mode or descriptor.")
 
     filename = f"hermes_{hermes_core.INST_TO_SHORTNAME[instrument]}_{mode}_{level}{test_str}_{descriptor}_{time_str}_v{version}"
     filename = filename.replace("__", "_")  # reformat if mode or descriptor not given
@@ -118,9 +113,7 @@ def parse_science_filename(filepath):
 
     if file_ext == ".bin":
         if filename_components[1] not in hermes_core.INST_TARGETNAMES:
-            raise ValueError(
-                f"File {filename} not recognized. Not a valid target name."
-            )
+            raise ValueError(f"File {filename} not recognized. Not a valid target name.")
 
         offset = 1 if len(filename_components) > 5 else 0
 
@@ -140,14 +133,12 @@ def parse_science_filename(filepath):
 
     elif file_ext == ".cdf":
         if filename_components[1] not in hermes_core.INST_SHORTNAMES:
-            raise ValueError(
-                "File {filename} not recognized. Not a valid instrument name."
-            )
+            raise ValueError("File {filename} not recognized. Not a valid instrument name.")
 
         #  reverse the dictionary to look up instrument name from the short name
         from_shortname = {v: k for k, v in hermes_core.INST_TO_SHORTNAME.items()}
 
-        result["time"] = Time(filename_components[-2], format="isot")
+        result["time"] = Time.strptime(filename_components[-2], TIME_FORMAT)
 
         # mode and descriptor are optional so need to figure out if one or both or none is included
         if filename_components[2][0:2] not in VALID_DATA_LEVELS:

--- a/hermes_core/util/util.py
+++ b/hermes_core/util/util.py
@@ -11,7 +11,6 @@ import hermes_core
 __all__ = ["create_science_filename", "parse_science_filename", "VALID_DATA_LEVELS"]
 
 TIME_FORMAT_L0 = "%Y%j-%H%M%S"
-TIME_FORMAT = "%Y%m%d_%H%M%S"
 VALID_DATA_LEVELS = ["l0", "l1", "ql", "l2", "l3", "l4"]
 FILENAME_EXTENSION = ".cdf"
 
@@ -45,9 +44,9 @@ def create_science_filename(
     test_str = ""
 
     if isinstance(time, str):
-        time_str = Time(time, format="isot").strftime(TIME_FORMAT)
+        time_str = Time(time, format="isot").isot
     else:
-        time_str = time.strftime(TIME_FORMAT)
+        time_str = time.isot
 
     if instrument not in hermes_core.INST_NAMES:
         raise ValueError(
@@ -148,9 +147,7 @@ def parse_science_filename(filepath):
         #  reverse the dictionary to look up instrument name from the short name
         from_shortname = {v: k for k, v in hermes_core.INST_TO_SHORTNAME.items()}
 
-        result["time"] = Time.strptime(
-            filename_components[-3] + "_" + filename_components[-2], TIME_FORMAT
-        )
+        result["time"] = Time(filename_components[-2], format="isot")
 
         # mode and descriptor are optional so need to figure out if one or both or none is included
         if filename_components[2][0:2] not in VALID_DATA_LEVELS:
@@ -159,13 +156,15 @@ def parse_science_filename(filepath):
             result["level"] = filename_components[3].replace("test", "")
             if "test" in filename_components[3]:
                 result["test"] = True
-            if len(filename_components) == 8:
+            if len(filename_components) == 7:
+                print(f"HERER::: {filename_components[4]}")
                 result["descriptor"] = filename_components[4]
         else:
             result["level"] = filename_components[2].replace("test", "")
             if "test" in filename_components[2]:
                 result["test"] = True
-            if len(filename_components) == 7:
+            if len(filename_components) == 6:
+                print(f"HERER::: {filename_components[3]}")
                 result["descriptor"] = filename_components[3]
     else:
         raise ValueError(f"File extension {file_ext} not recognized.")

--- a/hermes_core/util/util.py
+++ b/hermes_core/util/util.py
@@ -16,7 +16,9 @@ VALID_DATA_LEVELS = ["l0", "l1", "ql", "l2", "l3", "l4"]
 FILENAME_EXTENSION = ".cdf"
 
 
-def create_science_filename(instrument, time, level, version, mode="", descriptor="", test=False):
+def create_science_filename(
+    instrument, time, level, version, mode="", descriptor="", test=False
+):
     """Return a compliant filename. The format is defined as
 
     hermes_{inst}_{mode}_{level}{test}_{descriptor}_{time}_v{version}.cdf
@@ -57,7 +59,9 @@ def create_science_filename(instrument, time, level, version, mode="", descripto
         )
     # check that version is in the right format with three parts
     if len(version.split(".")) != 3:
-        raise ValueError(f"Version, {version}, is not formatted correctly. Should be X.Y.Z")
+        raise ValueError(
+            f"Version, {version}, is not formatted correctly. Should be X.Y.Z"
+        )
     # check that version has integers in each part
     for item in version.split("."):
         try:
@@ -70,7 +74,9 @@ def create_science_filename(instrument, time, level, version, mode="", descripto
 
     # the parse_science_filename function depends on _ not being present elsewhere
     if ("_" in mode) or ("_" in descriptor):
-        raise ValueError("The underscore symbol _ is not allowed in mode or descriptor.")
+        raise ValueError(
+            "The underscore symbol _ is not allowed in mode or descriptor."
+        )
 
     filename = f"hermes_{hermes_core.INST_TO_SHORTNAME[instrument]}_{mode}_{level}{test_str}_{descriptor}_{time_str}_v{version}"
     filename = filename.replace("__", "_")  # reformat if mode or descriptor not given
@@ -113,7 +119,9 @@ def parse_science_filename(filepath):
 
     if file_ext == ".bin":
         if filename_components[1] not in hermes_core.INST_TARGETNAMES:
-            raise ValueError(f"File {filename} not recognized. Not a valid target name.")
+            raise ValueError(
+                f"File {filename} not recognized. Not a valid target name."
+            )
 
         offset = 1 if len(filename_components) > 5 else 0
 
@@ -133,7 +141,9 @@ def parse_science_filename(filepath):
 
     elif file_ext == ".cdf":
         if filename_components[1] not in hermes_core.INST_SHORTNAMES:
-            raise ValueError("File {filename} not recognized. Not a valid instrument name.")
+            raise ValueError(
+                "File {filename} not recognized. Not a valid instrument name."
+            )
 
         #  reverse the dictionary to look up instrument name from the short name
         from_shortname = {v: k for k, v in hermes_core.INST_TO_SHORTNAME.items()}

--- a/hermes_core/util/util.py
+++ b/hermes_core/util/util.py
@@ -157,14 +157,12 @@ def parse_science_filename(filepath):
             if "test" in filename_components[3]:
                 result["test"] = True
             if len(filename_components) == 7:
-                print(f"HERER::: {filename_components[4]}")
                 result["descriptor"] = filename_components[4]
         else:
             result["level"] = filename_components[2].replace("test", "")
             if "test" in filename_components[2]:
                 result["test"] = True
             if len(filename_components) == 6:
-                print(f"HERER::: {filename_components[3]}")
                 result["descriptor"] = filename_components[3]
     else:
         raise ValueError(f"File extension {file_ext} not recognized.")


### PR DESCRIPTION
This changes the time format used in HERMES file names to the format suggested by SPDF. https://spdf.gsfc.nasa.gov/guidelines/filenaming_recommendations.html

closes #71