### PR TITLE
Add Attributes and Derivation Functions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,16 +38,9 @@
 			}
 		}
 	},
-	"customizations": {
-		"vscode": {
-			"settings": {
-				"extensions.verifySignature": false
-			}
-		}
-	},
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"ms-python.python@2023.6.1",
+		"ms-python.python",
 		"ms-python.vscode-pylance",
 		"marklarah.pre-commit-vscode",
 		"ms-toolsai.jupyter",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,9 +38,16 @@
 			}
 		}
 	},
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"extensions.verifySignature": false
+			}
+		}
+	},
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"ms-python.python",
+		"ms-python.python@2023.6.1",
 		"ms-python.vscode-pylance",
 		"marklarah.pre-commit-vscode",
 		"ms-toolsai.jupyter",

--- a/hermes_core/data/hermes_default_global_cdf_attrs_schema.yaml
+++ b/hermes_core/data/hermes_default_global_cdf_attrs_schema.yaml
@@ -1,3 +1,11 @@
+CDF_Lib_version:
+  description: > 
+    Version of the CDF Binaries library used to generate the CDF File
+  default: null
+  derived: true
+  required: true # NOT Required in ISTP Guide (Derived)
+  validate: false
+  overwrite: false
 DOI:
   description: > 
     DOI is a persistent Unique Digital Identifier with the form
@@ -84,6 +92,14 @@ Generation_date:
   required: true # NOT Required in ISTP Guide (Recommended)
   validate: true
   overwrite: true
+HERMES_version:
+  description: >
+    Version of `hermes_core` originally used to generate the given CDF File
+  default: null
+  derived: true
+  required: true # NOT Required in ISTP Guide (Derived)
+  validate: false
+  overwrite: false
 HTTP_LINK:
   description: >
     The 'HTTP_LINK', 'LINK_TEXT', and 'LINK_TITLE' attributes store the URL with a

--- a/hermes_core/tests/test_timedata.py
+++ b/hermes_core/tests/test_timedata.py
@@ -669,3 +669,55 @@ def test_overwrite_save():
 
         # with overwrite set there should be no error
         assert Path(td.save(output_path=tmpdirname, overwrite=True)).exists()
+
+
+def test_without_cdf_lib():
+    """Function to test TimeData Functions without the use of spacepy.pycdf libraries"""
+    # fmt: off
+    input_attrs = {
+        "DOI": "https://doi.org/<PREFIX>/<SUFFIX>",
+        "Data_level": "L1>Level 1",  # NOT AN ISTP ATTR
+        "Data_version": "0.0.1",
+        "Descriptor": "EEA>Electron Electrostatic Analyzer",
+        "Data_product_descriptor": "odpd",
+        "HTTP_LINK": [
+            "https://spdf.gsfc.nasa.gov/istp_guide/istp_guide.html",
+            "https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html",
+            "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html"
+        ],
+        "Instrument_mode": "default",  # NOT AN ISTP ATTR
+        "Instrument_type": "Electric Fields (space)",
+        "LINK_TEXT": [
+            "ISTP Guide",
+            "Global Attrs",
+            "Variable Attrs"
+        ],
+        "LINK_TITLE": [
+            "ISTP Guide",
+            "Global Attrs",
+            "Variable Attrs"
+        ],
+        "MODS": [
+            "v0.0.0 - Original version.",
+            "v1.0.0 - Include trajectory vectors and optics state.",
+            "v1.1.0 - Update metadata: counts -> flux.",
+            "v1.2.0 - Added flux error.",
+            "v1.3.0 - Trajectory vector errors are now deltas."
+        ],
+        "PI_affiliation": "HERMES",
+        "PI_name": "HERMES SOC",
+        "TEXT": "Valid Test Case",
+    }
+    # fmt: on
+    # Get Test TimeSeries
+    ts = get_test_timeseries()
+
+    # Disable CDF Libraries
+    import spacepy.pycdf as pycdf
+
+    pycdf.lib = None
+
+    # Initialize a CDF File Wrapper
+    test_data = TimeData(ts, meta=input_attrs)
+
+    assert test_data.meta["CDF_Lib_version"] == "unknown version"

--- a/hermes_core/util/schema.py
+++ b/hermes_core/util/schema.py
@@ -1368,7 +1368,7 @@ class CDFSchema(HERMESDataSchema):
                 import spacepy.pycdf as pycdf
 
                 cdf_lib_version = pycdf.lib.version
-            except ImportError:
+            except (ImportError, AttributeError) as e:
                 cdf_lib_version = "unknown version"
         else:
             cdf_lib_version = data.meta[attr_name]

--- a/hermes_core/util/schema.py
+++ b/hermes_core/util/schema.py
@@ -739,6 +739,10 @@ class CDFSchema(HERMESDataSchema):
             return self._get_logical_source(data)
         elif attr_name == "Logical_source_description":
             return self._get_logical_source_description(data)
+        elif attr_name == "HERMES_version":
+            return self._get_hermes_version(data)
+        elif attr_name == "CDF_Lib_version":
+            return self._get_cdf_lib_version(data)
         else:
             raise ValueError(f"Derivation for Attribute ({attr_name}) Not Recognized")
 
@@ -1346,6 +1350,29 @@ class CDFSchema(HERMESDataSchema):
         else:
             instr_mode = data.meta["Instrument_mode"]
         return instr_mode.lower()  # Makse sure its all lowercase
+
+    def _get_hermes_version(self, data):
+        """Function to get the version of HERMES used to generate the data"""
+        attr_name = "HERMES_version"
+        if (attr_name not in data.meta) or (not data.meta[attr_name]):
+            hermes_version = hermes_core.__version__
+        else:
+            hermes_version = data.meta[attr_name]
+        return hermes_version
+
+    def _get_cdf_lib_version(self, data):
+        """Function to get the version of CDF library used to generate the data"""
+        attr_name = "CDF_Lib_version"
+        if (attr_name not in data.meta) or (not data.meta[attr_name]):
+            try:
+                import spacepy.pycdf as pycdf
+
+                cdf_lib_version = pycdf.lib.version
+            except ImportError:
+                cdf_lib_version = "unknown version"
+        else:
+            cdf_lib_version = data.meta[attr_name]
+        return cdf_lib_version
 
 
 class NetCDFSchema(HERMESDataSchema):


### PR DESCRIPTION
This PR adds version information about the version of `hermes_core` used to generate the CDF file as well as the CDF binaries used. This will help give teams greater situational awareness and debug future issues of compatibility if they arise. 

closes #76