### PR TITLE
HREMES Schema Refactoring and Consolidation

### DIFF
--- a/docs/user-guide/cdf_format_guide.rst
+++ b/docs/user-guide/cdf_format_guide.rst
@@ -200,12 +200,12 @@ information is provided:
 * description: (`str`) A brief description of the attribute
 * default: (`str`) The default value used if none is provided
 * derived: (`bool`) Whether the attibute can be derived by the HERMES 
-  :py:class:`~hermes_core.util.schema.CDFSchema` class
+  :py:class:`~hermes_core.util.schema.HERMESDataSchema` class
 * required: (`bool`) Whether the attribute is required by HERMES standards
 * validate: (`bool`) Whether the attribute is included in the 
   :py:func:`~hermes_core.util.validation.validate` checks (Note, not all attributes that 
   are required are validated)
-* overwrite: (`bool`) Whether the :py:class:`~hermes_core.util.schema.CDFSchema`
+* overwrite: (`bool`) Whether the :py:class:`~hermes_core.util.schema.HERMESDataSchema`
   attribute derivations will overwrite an existing attribute value with an updated 
   attribute value from the derivation process.
 
@@ -528,9 +528,9 @@ information is provided:
 
 * description: (`str`) A brief description of the attribute
 * derived: (`bool`) Whether the attibute can be derived by the HERMES 
-  :py:class:`~hermes_core.util.schema.CDFSchema` class
+  :py:class:`~hermes_core.util.schema.HERMESDataSchema` class
 * required: (`bool`) Whether the attribute is required by HERMES standards
-* overwrite: (`bool`) Whether the :py:class:`~hermes_core.util.schema.CDFSchema`
+* overwrite: (`bool`) Whether the :py:class:`~hermes_core.util.schema.HERMESDataSchema`
   attribute derivations will overwrite an existing attribute value with an updated 
   attribute value from the derivation process.
 * valid_values: (`list`) List of allowed values the attribute can take for HERMES products,

--- a/docs/user-guide/reading_writing_data.rst
+++ b/docs/user-guide/reading_writing_data.rst
@@ -186,7 +186,7 @@ lest this subset of global metadata attributes.
 Derived Global Attributes
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :py:class:`~hermes_core.util.schema.CDFSchema` class derives several global metadata 
+The :py:class:`~hermes_core.util.schema.HERMESDataSchema` class derives several global metadata 
 attributes required for ISTP compliance. The following global attribtues are derived:
 
 - `Data_type`
@@ -269,7 +269,7 @@ to be provided upon instantiation:
 Derived Variable Attributes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :py:class:`~hermes_core.util.schema.CDFSchema` class derives several variable metadata
+The :py:class:`~hermes_core.util.schema.HERMESDataSchema` class derives several variable metadata
 attributes required for ISTP compliance.
 
 -  `TIME_BASE`

--- a/hermes_core/data/hermes_default_variable_cdf_attrs_schema.yaml
+++ b/hermes_core/data/hermes_default_variable_cdf_attrs_schema.yaml
@@ -344,16 +344,6 @@ attribute_key:
     overwrite: false
     valid_values: null
     alternate: null
-time_series:
-  - TIME_BASE
-  - RESOLUTION
-  - TIME_SCALE
-  - REFERENCE_POSITION
-  - LEAP_SECONDS_INCLUDED
-  - ABSOLUTE_ERROR
-  - RELATIVE_ERROR
-  - BIN_LOCATION
-  - VAR_TYPE
 data:
   - CATDESC
   - DEPEND_0

--- a/hermes_core/data/hermes_default_variable_cdf_attrs_schema.yaml
+++ b/hermes_core/data/hermes_default_variable_cdf_attrs_schema.yaml
@@ -181,6 +181,7 @@ attribute_key:
     required: true
     overwrite: true
     valid_values: null
+    alternate: null
   FORMAT:           # NOTE Only one of FORMAT or FORM_PTR should be present
     description: >
       This field allows software to properly format the associated data when displayed on a

--- a/hermes_core/tests/test_timedata.py
+++ b/hermes_core/tests/test_timedata.py
@@ -720,3 +720,6 @@ def test_without_cdf_lib():
     test_data = TimeData(ts, meta=input_attrs)
 
     assert test_data.meta["CDF_Lib_version"] == "unknown version"
+
+    # Reset/ Re-Enable CDF Libraries
+    pycdf.lib = pycdf.Library(pycdf._libpath, pycdf._library)

--- a/hermes_core/tests/test_timedata.py
+++ b/hermes_core/tests/test_timedata.py
@@ -37,16 +37,17 @@ def get_bad_timeseries():
 
 
 def get_test_timeseries():
-    ts = TimeSeries()
-
-    # Create an astropy.Time object
-    time = np.arange(10)
-    time_col = Time(time, format="unix")
-    ts["time"] = time_col
+    ts = TimeSeries(
+        time_start="2016-03-22T12:30:31",
+        time_delta=3 * u.s,
+        data={
+            "measurement": Quantity(value=random(size=(10)), unit="m", dtype=np.uint16)
+        },
+    )
 
     # Add Measurement
-    quant = Quantity(value=random(size=(10)), unit="m", dtype=np.uint16)
-    ts["measurement"] = quant
+    # quant = Quantity(value=random(size=(10)), unit="m", dtype=np.uint16)
+    # ts["measurement"] = quant
     ts["measurement"].meta = OrderedDict(
         {
             "VAR_TYPE": "metadata",
@@ -59,7 +60,7 @@ def get_test_timeseries():
 def get_test_timedata():
     ts = TimeSeries(
         time_start="2016-03-22T12:30:31",
-        time_delta=3 * u.s,
+        time_delta=3 * u.ns,
         data={"Bx": Quantity([1, 2, 3, 4], "gauss", dtype=np.uint16)},
     )
     input_attrs = TimeData.global_attribute_template("eea", "l1", "1.0.0")
@@ -431,6 +432,7 @@ def test_timedata_generate_valid_cdf():
 
         # Validate the generated CDF File
         result = validate(filepath=test_file_output_path)
+        print(result)
         assert len(result) <= 1  # TODO Logical Source and File ID Do not Agree
 
         # Remove the File

--- a/hermes_core/tests/test_timedata.py
+++ b/hermes_core/tests/test_timedata.py
@@ -432,7 +432,6 @@ def test_timedata_generate_valid_cdf():
 
         # Validate the generated CDF File
         result = validate(filepath=test_file_output_path)
-        print(result)
         assert len(result) <= 1  # TODO Logical Source and File ID Do not Agree
 
         # Remove the File

--- a/hermes_core/tests/test_timedata.py
+++ b/hermes_core/tests/test_timedata.py
@@ -37,17 +37,16 @@ def get_bad_timeseries():
 
 
 def get_test_timeseries():
-    ts = TimeSeries(
-        time_start="2016-03-22T12:30:31",
-        time_delta=3 * u.s,
-        data={
-            "measurement": Quantity(value=random(size=(10)), unit="m", dtype=np.uint16)
-        },
-    )
+    ts = TimeSeries()
+
+    # Create an astropy.Time object
+    time = np.arange(10)
+    time_col = Time(time, format="unix")
+    ts["time"] = time_col
 
     # Add Measurement
-    # quant = Quantity(value=random(size=(10)), unit="m", dtype=np.uint16)
-    # ts["measurement"] = quant
+    quant = Quantity(value=random(size=(10)), unit="m", dtype=np.uint16)
+    ts["measurement"] = quant
     ts["measurement"].meta = OrderedDict(
         {
             "VAR_TYPE": "metadata",
@@ -60,7 +59,7 @@ def get_test_timeseries():
 def get_test_timedata():
     ts = TimeSeries(
         time_start="2016-03-22T12:30:31",
-        time_delta=3 * u.ns,
+        time_delta=3 * u.s,
         data={"Bx": Quantity([1, 2, 3, 4], "gauss", dtype=np.uint16)},
     )
     input_attrs = TimeData.global_attribute_template("eea", "l1", "1.0.0")
@@ -116,6 +115,7 @@ def test_timedata_valid_attrs():
         "Descriptor": "EEA>Electron Electrostatic Analyzer",
         "Data_level": "l1>Level 1",
         "Data_version": "v0.0.1",
+        "Start_time": datetime.datetime.now()
     }
     # fmt: on
 
@@ -431,7 +431,7 @@ def test_timedata_generate_valid_cdf():
 
         # Validate the generated CDF File
         result = validate(filepath=test_file_output_path)
-        assert len(result) <= 1  # Logical Source and File ID Do not Agree
+        assert len(result) <= 1  # TODO Logical Source and File ID Do not Agree
 
         # Remove the File
         test_file_cache_path = Path(test_file_output_path)
@@ -532,7 +532,7 @@ def test_timedata_from_cdf():
 
         # Validate the generated CDF File
         result = validate(test_file_output_path)
-        assert len(result) <= 1  # Logical Source and File ID Do not Agree
+        assert len(result) <= 1  # TODO Logical Source and File ID Do not Agree
 
         # Try to Load the CDF File in a new CDFWriter
         new_writer = TimeData.load(test_file_output_path)
@@ -546,7 +546,7 @@ def test_timedata_from_cdf():
 
         # Validate the generated CDF File
         result2 = validate(test_file_output_path2)
-        assert len(result2) <= 1  # Logical Source and File ID Do not Agree
+        assert len(result2) <= 1  # TODO Logical Source and File ID Do not Agree
         assert len(result) == len(result2)
 
 
@@ -669,55 +669,3 @@ def test_overwrite_save():
 
         # with overwrite set there should be no error
         assert Path(td.save(output_path=tmpdirname, overwrite=True)).exists()
-
-
-def test_without_cdf_lib():
-    """Function to test TimeData Functions without the use of spacepy.pycdf libraries"""
-    # fmt: off
-    input_attrs = {
-        "DOI": "https://doi.org/<PREFIX>/<SUFFIX>",
-        "Data_level": "L1>Level 1",  # NOT AN ISTP ATTR
-        "Data_version": "0.0.1",
-        "Descriptor": "EEA>Electron Electrostatic Analyzer",
-        "Data_product_descriptor": "odpd",
-        "HTTP_LINK": [
-            "https://spdf.gsfc.nasa.gov/istp_guide/istp_guide.html",
-            "https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html",
-            "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html"
-        ],
-        "Instrument_mode": "default",  # NOT AN ISTP ATTR
-        "Instrument_type": "Electric Fields (space)",
-        "LINK_TEXT": [
-            "ISTP Guide",
-            "Global Attrs",
-            "Variable Attrs"
-        ],
-        "LINK_TITLE": [
-            "ISTP Guide",
-            "Global Attrs",
-            "Variable Attrs"
-        ],
-        "MODS": [
-            "v0.0.0 - Original version.",
-            "v1.0.0 - Include trajectory vectors and optics state.",
-            "v1.1.0 - Update metadata: counts -> flux.",
-            "v1.2.0 - Added flux error.",
-            "v1.3.0 - Trajectory vector errors are now deltas."
-        ],
-        "PI_affiliation": "HERMES",
-        "PI_name": "HERMES SOC",
-        "TEXT": "Valid Test Case",
-    }
-    # fmt: on
-    # Get Test TimeSeries
-    ts = get_test_timeseries()
-
-    # Disable CDF Libraries
-    import spacepy.pycdf as pycdf
-
-    pycdf.lib = None
-
-    # Initialize a CDF File Wrapper
-    test_data = TimeData(ts, meta=input_attrs)
-
-    assert test_data.meta["CDF_Lib_version"] == "unknown version"

--- a/hermes_core/tests/test_timedata.py
+++ b/hermes_core/tests/test_timedata.py
@@ -115,7 +115,6 @@ def test_timedata_valid_attrs():
         "Descriptor": "EEA>Electron Electrostatic Analyzer",
         "Data_level": "l1>Level 1",
         "Data_version": "v0.0.1",
-        "Start_time": datetime.datetime.now()
     }
     # fmt: on
 
@@ -431,7 +430,7 @@ def test_timedata_generate_valid_cdf():
 
         # Validate the generated CDF File
         result = validate(filepath=test_file_output_path)
-        assert len(result) <= 1  # TODO Logical Source and File ID Do not Agree
+        assert len(result) <= 1  # Logical Source and File ID Do not Agree
 
         # Remove the File
         test_file_cache_path = Path(test_file_output_path)
@@ -532,7 +531,7 @@ def test_timedata_from_cdf():
 
         # Validate the generated CDF File
         result = validate(test_file_output_path)
-        assert len(result) <= 1  # TODO Logical Source and File ID Do not Agree
+        assert len(result) <= 1  # Logical Source and File ID Do not Agree
 
         # Try to Load the CDF File in a new CDFWriter
         new_writer = TimeData.load(test_file_output_path)
@@ -546,7 +545,7 @@ def test_timedata_from_cdf():
 
         # Validate the generated CDF File
         result2 = validate(test_file_output_path2)
-        assert len(result2) <= 1  # TODO Logical Source and File ID Do not Agree
+        assert len(result2) <= 1  # Logical Source and File ID Do not Agree
         assert len(result) == len(result2)
 
 
@@ -669,3 +668,55 @@ def test_overwrite_save():
 
         # with overwrite set there should be no error
         assert Path(td.save(output_path=tmpdirname, overwrite=True)).exists()
+
+
+def test_without_cdf_lib():
+    """Function to test TimeData Functions without the use of spacepy.pycdf libraries"""
+    # fmt: off
+    input_attrs = {
+        "DOI": "https://doi.org/<PREFIX>/<SUFFIX>",
+        "Data_level": "L1>Level 1",  # NOT AN ISTP ATTR
+        "Data_version": "0.0.1",
+        "Descriptor": "EEA>Electron Electrostatic Analyzer",
+        "Data_product_descriptor": "odpd",
+        "HTTP_LINK": [
+            "https://spdf.gsfc.nasa.gov/istp_guide/istp_guide.html",
+            "https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html",
+            "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html"
+        ],
+        "Instrument_mode": "default",  # NOT AN ISTP ATTR
+        "Instrument_type": "Electric Fields (space)",
+        "LINK_TEXT": [
+            "ISTP Guide",
+            "Global Attrs",
+            "Variable Attrs"
+        ],
+        "LINK_TITLE": [
+            "ISTP Guide",
+            "Global Attrs",
+            "Variable Attrs"
+        ],
+        "MODS": [
+            "v0.0.0 - Original version.",
+            "v1.0.0 - Include trajectory vectors and optics state.",
+            "v1.1.0 - Update metadata: counts -> flux.",
+            "v1.2.0 - Added flux error.",
+            "v1.3.0 - Trajectory vector errors are now deltas."
+        ],
+        "PI_affiliation": "HERMES",
+        "PI_name": "HERMES SOC",
+        "TEXT": "Valid Test Case",
+    }
+    # fmt: on
+    # Get Test TimeSeries
+    ts = get_test_timeseries()
+
+    # Disable CDF Libraries
+    import spacepy.pycdf as pycdf
+
+    pycdf.lib = None
+
+    # Initialize a CDF File Wrapper
+    test_data = TimeData(ts, meta=input_attrs)
+
+    assert test_data.meta["CDF_Lib_version"] == "unknown version"

--- a/hermes_core/timedata.py
+++ b/hermes_core/timedata.py
@@ -10,8 +10,8 @@ from astropy.timeseries import TimeSeries
 from astropy.table import vstack
 from astropy import units as u
 import hermes_core
-from hermes_core.util.io import CDFHandler, NetCDFHandler
-from hermes_core.util.schema import CDFSchema
+from hermes_core.util.io import CDFHandler
+from hermes_core.util.schema import HERMESDataSchema
 from hermes_core.util.exceptions import warn_user
 from hermes_core.util.util import VALID_DATA_LEVELS
 
@@ -93,7 +93,7 @@ class TimeData:
                     self._data[col].meta.update(data[col].meta)
 
         # Derive Metadata
-        self.schema = CDFSchema()
+        self.schema = HERMESDataSchema()
         self._derive_metadata()
 
     @property
@@ -239,7 +239,7 @@ class TimeData:
         template : `collections.OrderedDict`
             A template for required global attributes.
         """
-        meta = CDFSchema.global_attribute_template()
+        meta = HERMESDataSchema.global_attribute_template()
 
         # Check the Optional Instrument Name
         if instr_name:
@@ -284,11 +284,11 @@ class TimeData:
         template : `collections.OrderedDict`
             A template for required variable attributes that must be provided.
         """
-        return CDFSchema.measurement_attribute_template()
+        return HERMESDataSchema.measurement_attribute_template()
 
     def _derive_metadata(self):
         """
-        Funtion to derive global and measurement metadata based on a CDFSchema
+        Funtion to derive global and measurement metadata based on a HERMESDataSchema
         """
 
         # Get Default Metadata
@@ -612,8 +612,6 @@ class TimeData:
         # Create the appropriate handler object based on file type
         if file_extension == ".cdf":
             handler = CDFHandler()
-        elif file_extension == ".nc":
-            handler = NetCDFHandler()
         else:
             raise ValueError(f"Unsupported file type: {file_extension}")
 

--- a/hermes_core/util/io.py
+++ b/hermes_core/util/io.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from astropy.timeseries import TimeSeries
 from astropy.time import Time
 from hermes_core.util.exceptions import warn_user
-from hermes_core.util.schema import CDFSchema
+from hermes_core.util.schema import HERMESDataSchema
 
 __all__ = ["CDFHandler"]
 
@@ -66,7 +66,7 @@ class CDFHandler(TimeDataIOHandler):
         super().__init__()
 
         # CDF Schema
-        self.schema = CDFSchema()
+        self.schema = HERMESDataSchema()
 
     def load_data(self, file_path):
         """
@@ -167,9 +167,7 @@ class CDFHandler(TimeDataIOHandler):
             # Make sure the Value is not None
             # We cannot add None Values to the CDF Global Attrs
             if attr_value is None:
-                raise ValueError(
-                    f"Cannot Add gAttr: {attr_name}. Value was {str(attr_value)} "
-                )
+                cdf_file.attrs[attr_name] = ""
             else:
                 # Add the Attribute to the CDF File
                 cdf_file.attrs[attr_name] = attr_value
@@ -195,50 +193,3 @@ class CDFHandler(TimeDataIOHandler):
                     else:
                         # Add the Attribute to the CDF File
                         cdf_file[var_name].attrs[var_attr_name] = var_attr_val
-
-
-# ================================================================================================
-#                                   NET CDF HANDLER
-# ================================================================================================
-
-
-class NetCDFHandler(TimeDataIOHandler):
-    """
-    A concrete implementation of TimeDataIOHandler for handling heliophysics data in NetCDF format.
-
-    This class provides methods to load and save heliophysics data from/to a NetCDF file.
-    """
-
-    def load_data(self, file_path):
-        """
-        Load heliophysics data from a NetCDF file.
-
-        Parameters
-        ----------
-        file_path : `str`
-            The path to the NetCDF file.
-
-        Returns
-        -------
-        data : `~astropy.time.TimeSeries`
-            An instance of `TimeSeries` containing the loaded data.
-        """
-        pass
-
-    def save_data(self, data, file_path):
-        """
-        Save heliophysics data to a NetCDF file.
-
-        Parameters
-        ----------
-        data : `hermes_core.timedata.TimeData`
-            An instance of `TimeData` containing the data to be saved.
-        file_path : `str`
-            The path to save the NetCDF file.
-
-        Returns
-        -------
-        path : `str`
-            A path to the saved file.
-        """
-        pass

--- a/hermes_core/util/schema.py
+++ b/hermes_core/util/schema.py
@@ -636,7 +636,7 @@ class HERMESDataSchema:
             raise ValueError("Unknown data type: {}".format(cdftype))
         return (inf.min, inf.max)
 
-    def derive_measurement_attributes(self, data, var_name):
+    def derive_measurement_attributes(self, data, var_name, guess_types=None):
         """
         Function to derive metadata for the given measurement.
 
@@ -646,6 +646,8 @@ class HERMESDataSchema:
             An instance of `TimeData` to derive metadata from
         var_name : `str`
             The name of the measurement to derive metadata for
+        guess_types : `list[int]`, optional
+            Guessed CDF Type of the variable
 
         Returns
         -------
@@ -654,21 +656,33 @@ class HERMESDataSchema:
         """
         measurement_attributes = OrderedDict()
 
+        # Get the Variable Data
+        var_data = data[var_name]
+        if not guess_types:
+            if var_name == "time":
+                # Guess the const CDF Data Type
+                (guess_dims, guess_types, guess_elements) = self._types(
+                    var_data.to_datetime()
+                )
+            else:
+                # Guess the const CDF Data Type
+                (guess_dims, guess_types, guess_elements) = self._types(var_data.value)
+
         # Check the Attributes that can be derived
         if not var_name == "time":
-            measurement_attributes["DEPEND_0"] = self._get_depend(data)
-        measurement_attributes["DISPLAY_TYPE"] = self._get_display_type(data, var_name)
-        measurement_attributes["FIELDNAM"] = self._get_fieldnam(data, var_name)
-        measurement_attributes["FILLVAL"] = self._get_fillval(data, var_name)
-        measurement_attributes["FORMAT"] = self._get_format(data, var_name)
+            measurement_attributes["DEPEND_0"] = self._get_depend()
+        measurement_attributes["DISPLAY_TYPE"] = self._get_display_type()
+        measurement_attributes["FIELDNAM"] = self._get_fieldnam(var_name)
+        measurement_attributes["FILLVAL"] = self._get_fillval(guess_types[0])
+        measurement_attributes["FORMAT"] = self._get_format(var_data, guess_types[0])
         measurement_attributes["LABLAXIS"] = self._get_lablaxis(data, var_name)
         measurement_attributes["SI_CONVERSION"] = self._get_si_conversion(
             data, var_name
         )
         measurement_attributes["UNITS"] = self._get_units(data, var_name)
-        measurement_attributes["VALIDMIN"] = self._get_validmin(data, var_name)
-        measurement_attributes["VALIDMAX"] = self._get_validmax(data, var_name)
-        measurement_attributes["VAR_TYPE"] = self._get_var_type(data, var_name)
+        measurement_attributes["VALIDMIN"] = self._get_validmin(guess_types[0])
+        measurement_attributes["VALIDMAX"] = self._get_validmax(guess_types[0])
+        measurement_attributes["VAR_TYPE"] = self._get_var_type()
         return measurement_attributes
 
     def derive_time_attributes(self, data):
@@ -685,13 +699,22 @@ class HERMESDataSchema:
         attributes : `OrderedDict`
             A dict containing `key: value` pairs of time metadata attributes.
         """
-        time_attributes = self.derive_measurement_attributes(data, "time")
+
+        # Get the Variable Data
+        var_data = data["time"]
+        (guess_dims, guess_types, guess_elements) = self._types(var_data.to_datetime())
+
+        time_attributes = self.derive_measurement_attributes(
+            data, "time", guess_types=guess_types
+        )
         # Check the Attributes that can be derived
-        time_attributes["REFERENCE_POSITION"] = self._get_reference_position(data)
+        time_attributes["REFERENCE_POSITION"] = self._get_reference_position(
+            guess_types[0]
+        )
         time_attributes["RESOLUTION"] = self._get_resolution(data)
-        time_attributes["TIME_BASE"] = self._get_time_base(data)
-        time_attributes["TIME_SCALE"] = self._get_time_scale(data)
-        time_attributes["UNITS"] = self._get_time_units(data)
+        time_attributes["TIME_BASE"] = self._get_time_base(guess_types[0])
+        time_attributes["TIME_SCALE"] = self._get_time_scale(guess_types[0])
+        time_attributes["UNITS"] = self._get_time_units(guess_types[0])
         return time_attributes
 
     def derive_global_attributes(self, data):
@@ -740,37 +763,28 @@ class HERMESDataSchema:
     #                             VARIABLE METADATA DERIVATIONS
     # =============================================================================================
 
-    def _get_depend(self, data):
+    def _get_depend(self):
         return "Epoch"
 
-    def _get_display_type(self, data, var_name):
+    def _get_display_type(self):
         return "time_series"
 
-    def _get_fieldnam(self, data, var_name):
+    def _get_fieldnam(self, var_name):
         if var_name != "time":
             return deepcopy(var_name)
         else:
             return "Epoch"
 
-    def _get_fillval(self, data, var_name):
+    def _get_fillval(self, guess_type):
         # Get the Variable Data
-        var_data = data[var_name]
-        if var_name == "time":
-            # Guess the const CDF Data Type
-            (guess_dims, guess_types, guess_elements) = self._types(
-                var_data.to_datetime()
-            )
-            # Get the FILLVAL for the gussed data type
-            fillval = self._fillval_helper(data, cdf_type=guess_types[0])
+        if guess_type == const.CDF_TIME_TT2000.value:
             return datetime.datetime(9999, 12, 31, 23, 59, 59, 999999)
         else:
-            # Guess the const CDF Data Type
-            (guess_dims, guess_types, guess_elements) = self._types(var_data.value)
             # Get the FILLVAL for the gussed data type
-            fillval = self._fillval_helper(data, cdf_type=guess_types[0])
+            fillval = self._fillval_helper(cdf_type=guess_type)
             return fillval
 
-    def _fillval_helper(self, data, cdf_type):
+    def _fillval_helper(self, cdf_type):
         # Fill value, indexed by the CDF type (numeric)
         fillvals = {}
         # Integers
@@ -796,25 +810,9 @@ class HERMESDataSchema:
         value = fillvals[cdf_type]
         return value
 
-    def _get_format(self, data, var_name):
-        # Get the Variable Data
-        var_data = data[var_name]
-        if var_name == "time":
-            # Guess the const CDF Data Type
-            (guess_dims, guess_types, guess_elements) = self._types(
-                var_data.to_datetime()
-            )
-            return self._format_helper(data, var_name, guess_types[0])
-        else:
-            # Guess the const CDF Data Type
-            (guess_dims, guess_types, guess_elements) = self._types(var_data.value)
-            return self._format_helper(data, var_name, guess_types[0])
-
-    def _format_helper(self, data, var_name, cdftype):
+    def _get_format(self, var_data, cdftype):
         minn = "VALIDMIN"
         maxx = "VALIDMAX"
-        # Get the Variable Data
-        var_data = data[var_name]
 
         if cdftype in (
             const.CDF_INT1.value,
@@ -933,25 +931,20 @@ class HERMESDataSchema:
             fmt = "A{}".format(len(var_data))
         else:
             raise ValueError(
-                "Couldn't find FORMAT for {} of type {}".format(
-                    var_name, self.cdftypenames.get(cdftype, "UNKNOWN")
+                "Couldn't find FORMAT for type {}".format(
+                    self.cdftypenames.get(cdftype, "UNKNOWN")
                 )
             )
         return fmt
 
     def _get_lablaxis(self, data, var_name):
-        # return f"{var_name} [{data[var_name].unit}]"
         return f"{var_name} [{self._get_units(data, var_name)}]"
 
-    def _get_reference_position(self, data):
-        # Get the Variable Data
-        var_data = data.time
-        # Guess the const CDF Data Type
-        (guess_dims, guess_types, guess_elements) = self._types(var_data.to_datetime())
-        if guess_types[0] == const.CDF_TIME_TT2000.value:
+    def _get_reference_position(self, guess_type):
+        if guess_type == const.CDF_TIME_TT2000.value:
             return "rotating Earth geoid"
         else:
-            msg = f"Reference Position for Time type ({guess_types[0]}) not found."
+            msg = f"Reference Position for Time type ({guess_type}) not found."
             raise TypeError(msg)
 
     def _get_resolution(self, data):
@@ -973,54 +966,30 @@ class HERMESDataSchema:
         # Get the Variable Data
         var_data = data[var_name]
         if var_name == "time":
-            time_unit_str = self._get_time_units(data)
-            time_unit = u.s
-            if time_unit_str == "ms":
-                time_unit = u.ms
-            if time_unit_str == "ns":
-                time_unit = u.ns
-            if time_unit_str == "ps":
-                time_unit = u.ns
-            conversion_rate = time_unit.to(u.s)
+            conversion_rate = u.ns.to(u.s)
             si_conversion = f"{conversion_rate:e}>{u.s}"
         else:
             conversion_rate = var_data.unit.to(var_data.si.unit)
             si_conversion = f"{conversion_rate:e}>{var_data.si.unit}"
         return si_conversion
 
-    def _get_time_base(self, data):
-        # Get the Variable Data
-        var_data = data.time
-        # Guess the const CDF Data Type
-        (guess_dims, guess_types, guess_elements) = self._types(var_data.to_datetime())
-        if guess_types[0] == const.CDF_TIME_TT2000.value:
+    def _get_time_base(self, guess_type):
+        if guess_type == const.CDF_TIME_TT2000.value:
             return "J2000"
         else:
-            raise TypeError(f"Time Base for Time type ({guess_types[0]}) not found.")
+            raise TypeError(f"Time Base for Time type ({guess_type}) not found.")
 
-    def _get_time_scale(self, data):
-        # Get the Variable Data
-        var_data = data.time
-        # Guess the const CDF Data Type
-        (guess_dims, guess_types, guess_elements) = self._types(var_data.to_datetime())
-        if guess_types[0] == const.CDF_TIME_TT2000.value:
+    def _get_time_scale(self, guess_type):
+        if guess_type == const.CDF_TIME_TT2000.value:
             return "Terrestrial Time (TT)"
         else:
-            raise TypeError(f"Time Scale for Time type ({guess_types[0]}) not found.")
+            raise TypeError(f"Time Scale for Time type ({guess_type}) not found.")
 
-    def _get_time_units(self, data):
-        # Get the Variable Data
-        var_data = data.time
-        # Guess the const CDF Data Type
-        (guess_dims, guess_types, guess_elements) = self._types(var_data.to_datetime())
-        if guess_types[0] == const.CDF_EPOCH.value:
-            return "ms"
-        if guess_types[0] == const.CDF_TIME_TT2000.value:
+    def _get_time_units(self, guess_type):
+        if guess_type == const.CDF_TIME_TT2000.value:
             return "ns"
-        if guess_types[0] == const.CDF_EPOCH16.value:
-            return "ps"
         else:
-            raise TypeError(f"Time Units for Time type ({guess_types[0]}) not found.")
+            raise TypeError(f"Time Units for Time type ({guess_type}) not found.")
 
     def _get_units(self, data, var_name):
         # Get the Variable Data
@@ -1031,43 +1000,29 @@ class HERMESDataSchema:
             unit = var_data.unit.to_string()
         return unit
 
-    def _get_validmin(self, data, var_name):
+    def _get_validmin(self, guess_type):
         # Get the Variable Data
-        var_data = data[var_name]
-        if var_name == "time":
-            # Guess the const CDF Data Type
-            (guess_dims, guess_types, guess_elements) = self._types(
-                var_data.to_datetime()
-            )
+        if guess_type == const.CDF_TIME_TT2000.value:
             # Get the Min Value
-            minval, maxval = self._get_minmax(guess_types[0])
+            minval, maxval = self._get_minmax(guess_type)
             return minval + datetime.timedelta(seconds=1)
         else:
-            # Guess the const CDF Data Type
-            (guess_dims, guess_types, guess_elements) = self._types(var_data.value)
             # Get the Min Value
-            minval, maxval = self._get_minmax(guess_types[0])
+            minval, maxval = self._get_minmax(guess_type)
             return minval
 
-    def _get_validmax(self, data, var_name):
+    def _get_validmax(self, guess_type):
         # Get the Variable Data
-        var_data = data[var_name]
-        if var_name == "time":
-            # Guess the const CDF Data Type
-            (guess_dims, guess_types, guess_elements) = self._types(
-                var_data.to_datetime()
-            )
+        if guess_type == const.CDF_TIME_TT2000.value:
             # Get the Max Value
-            minval, maxval = self._get_minmax(guess_types[0])
+            minval, maxval = self._get_minmax(guess_type)
             return maxval - datetime.timedelta(seconds=1)
         else:
-            # Guess the const CDF Data Type
-            (guess_dims, guess_types, guess_elements) = self._types(var_data.value)
             # Get the Max Value
-            minval, maxval = self._get_minmax(guess_types[0])
+            minval, maxval = self._get_minmax(guess_type)
             return maxval
 
-    def _get_var_type(self, data, var_name):
+    def _get_var_type(self):
         return "data"
 
     # =============================================================================================

--- a/hermes_core/util/schema.py
+++ b/hermes_core/util/schema.py
@@ -35,7 +35,9 @@ class HERMESDataSchema:
         self._global_attr_schema = HERMESDataSchema._load_default_global_attr_schema()
 
         # Data Validation and Compliance for Variable Data
-        self._variable_attr_schema = HERMESDataSchema._load_default_variable_attr_schema()
+        self._variable_attr_schema = (
+            HERMESDataSchema._load_default_variable_attr_schema()
+        )
 
         # Load Default Global Attributes
         self._default_global_attributes = HERMESDataSchema._load_default_attributes()
@@ -103,7 +105,9 @@ class HERMESDataSchema:
     def _load_default_global_attr_schema() -> dict:
         # The Default Schema file is contained in the `hermes_core/data` directory
         default_schema_path = str(
-            Path(hermes_core.__file__).parent / "data" / DEFAULT_GLOBAL_CDF_ATTRS_SCHEMA_FILE
+            Path(hermes_core.__file__).parent
+            / "data"
+            / DEFAULT_GLOBAL_CDF_ATTRS_SCHEMA_FILE
         )
         # Load the Schema
         return HERMESDataSchema._load_yaml_data(yaml_file_path=default_schema_path)
@@ -112,7 +116,9 @@ class HERMESDataSchema:
     def _load_default_variable_attr_schema() -> dict:
         # The Default Schema file is contained in the `hermes_core/data` directory
         default_schema_path = str(
-            Path(hermes_core.__file__).parent / "data" / DEFAULT_VARIABLE_CDF_ATTRS_SCHEMA_FILE
+            Path(hermes_core.__file__).parent
+            / "data"
+            / DEFAULT_VARIABLE_CDF_ATTRS_SCHEMA_FILE
         )
         # Load the Schema
         return HERMESDataSchema._load_yaml_data(yaml_file_path=default_schema_path)
@@ -121,9 +127,13 @@ class HERMESDataSchema:
     def _load_default_attributes():
         # The Default Attributes file is contained in the `hermes_core/data` directory
         default_attributes_path = str(
-            Path(hermes_core.__file__).parent / "data" / DEFAULT_GLOBAL_CDF_ATTRS_SCHEMA_FILE
+            Path(hermes_core.__file__).parent
+            / "data"
+            / DEFAULT_GLOBAL_CDF_ATTRS_SCHEMA_FILE
         )
-        global_schema = HERMESDataSchema._load_yaml_data(yaml_file_path=default_attributes_path)
+        global_schema = HERMESDataSchema._load_yaml_data(
+            yaml_file_path=default_attributes_path
+        )
         return {
             attr_name: info["default"]
             for attr_name, info in global_schema.items()
@@ -187,8 +197,12 @@ class HERMESDataSchema:
             A template for required variable attributes that must be provided.
         """
         template = OrderedDict()
-        measurement_attribute_schema = HERMESDataSchema._load_default_variable_attr_schema()
-        for attr_name, attr_schema in measurement_attribute_schema["attribute_key"].items():
+        measurement_attribute_schema = (
+            HERMESDataSchema._load_default_variable_attr_schema()
+        )
+        for attr_name, attr_schema in measurement_attribute_schema[
+            "attribute_key"
+        ].items():
             if attr_schema["required"] and not attr_schema["derived"]:
                 template[attr_name] = None
         return template
@@ -230,9 +244,9 @@ class HERMESDataSchema:
 
         # Strip the Description of New Lines
         for attr_name in global_attribute_schema.keys():
-            global_attribute_schema[attr_name]["description"] = global_attribute_schema[attr_name][
-                "description"
-            ].strip()
+            global_attribute_schema[attr_name]["description"] = global_attribute_schema[
+                attr_name
+            ]["description"].strip()
 
         # Get all the Attributes from the Schema
         attribute_names = list(global_attribute_schema.keys())
@@ -246,7 +260,9 @@ class HERMESDataSchema:
         if attribute_name and attribute_name in info["Attribute"]:
             info = info[info["Attribute"] == attribute_name]
         elif attribute_name and attribute_name not in info["Attribute"]:
-            raise KeyError(f"Cannot find Global Metadata for attribute name: {attribute_name}")
+            raise KeyError(
+                f"Cannot find Global Metadata for attribute name: {attribute_name}"
+            )
 
         return info
 
@@ -286,14 +302,16 @@ class HERMESDataSchema:
         ------
         KeyError: If attribute_name is not a recognized global attribute.
         """
-        measurement_attribute_schema = HERMESDataSchema._load_default_variable_attr_schema()
+        measurement_attribute_schema = (
+            HERMESDataSchema._load_default_variable_attr_schema()
+        )
         measurement_attribute_key = measurement_attribute_schema["attribute_key"]
 
         # Strip the Description of New Lines
         for attr_name in measurement_attribute_key.keys():
-            measurement_attribute_key[attr_name]["description"] = measurement_attribute_key[
-                attr_name
-            ]["description"].strip()
+            measurement_attribute_key[attr_name][
+                "description"
+            ] = measurement_attribute_key[attr_name]["description"].strip()
 
         # Create New Column to describe which VAR_TYPE's require the given attribute
         for attr_name in measurement_attribute_key.keys():
@@ -320,7 +338,9 @@ class HERMESDataSchema:
         if attribute_name and attribute_name in info["Attribute"]:
             info = info[info["Attribute"] == attribute_name]
         elif attribute_name and attribute_name not in info["Attribute"]:
-            raise KeyError(f"Cannot find Variable Metadata for attribute name: {attribute_name}")
+            raise KeyError(
+                f"Cannot find Variable Metadata for attribute name: {attribute_name}"
+            )
 
         return info
 
@@ -334,7 +354,9 @@ class HERMESDataSchema:
             The input data as a well-formed array; may be the input
             data exactly.
         """
-        msg = "Data must be well-formed, regular array of number, " "string, or datetime"
+        msg = (
+            "Data must be well-formed, regular array of number, " "string, or datetime"
+        )
         try:
             d = np.asanyarray(data)
         except ValueError:
@@ -639,7 +661,9 @@ class HERMESDataSchema:
         if not guess_types:
             if var_name == "time":
                 # Guess the const CDF Data Type
-                (guess_dims, guess_types, guess_elements) = self._types(var_data.to_datetime())
+                (guess_dims, guess_types, guess_elements) = self._types(
+                    var_data.to_datetime()
+                )
             else:
                 # Guess the const CDF Data Type
                 (guess_dims, guess_types, guess_elements) = self._types(var_data.value)
@@ -652,7 +676,9 @@ class HERMESDataSchema:
         measurement_attributes["FILLVAL"] = self._get_fillval(guess_types[0])
         measurement_attributes["FORMAT"] = self._get_format(var_data, guess_types[0])
         measurement_attributes["LABLAXIS"] = self._get_lablaxis(data, var_name)
-        measurement_attributes["SI_CONVERSION"] = self._get_si_conversion(data, var_name)
+        measurement_attributes["SI_CONVERSION"] = self._get_si_conversion(
+            data, var_name
+        )
         measurement_attributes["UNITS"] = self._get_units(data, var_name)
         measurement_attributes["VALIDMIN"] = self._get_validmin(guess_types[0])
         measurement_attributes["VALIDMAX"] = self._get_validmax(guess_types[0])
@@ -678,9 +704,13 @@ class HERMESDataSchema:
         var_data = data["time"]
         (guess_dims, guess_types, guess_elements) = self._types(var_data.to_datetime())
 
-        time_attributes = self.derive_measurement_attributes(data, "time", guess_types=guess_types)
+        time_attributes = self.derive_measurement_attributes(
+            data, "time", guess_types=guess_types
+        )
         # Check the Attributes that can be derived
-        time_attributes["REFERENCE_POSITION"] = self._get_reference_position(guess_types[0])
+        time_attributes["REFERENCE_POSITION"] = self._get_reference_position(
+            guess_types[0]
+        )
         time_attributes["RESOLUTION"] = self._get_resolution(data)
         time_attributes["TIME_BASE"] = self._get_time_base(guess_types[0])
         time_attributes["TIME_SCALE"] = self._get_time_scale(guess_types[0])
@@ -836,7 +866,8 @@ class HERMESDataSchema:
                             (
                                 8 * i
                                 for i in (1, 2, 4, 8)
-                                if getattr(const, "CDF_INT{}".format(i)).value == cdftype
+                                if getattr(const, "CDF_INT{}".format(i)).value
+                                == cdftype
                             )
                         )
                         - 1
@@ -847,7 +878,9 @@ class HERMESDataSchema:
             # powers of 10 (log10(10) = 1 but needs two digits)
             # -Make sure not taking log of zero
             if minval < 0:  # Need an extra space for the negative sign
-                fmt = "I{}".format(int(math.log10(max(abs(maxval), abs(minval), 1))) + 2)
+                fmt = "I{}".format(
+                    int(math.log10(max(abs(maxval), abs(minval), 1))) + 2
+                )
             else:
                 fmt = "I{}".format(int(math.log10(maxval) if maxval != 0 else 1) + 1)
         elif cdftype == const.CDF_TIME_TT2000.value:
@@ -871,14 +904,18 @@ class HERMESDataSchema:
             # (Use maxx-minn for this...effectively uses VALIDMIN/MAX for most
             # cases.)
             if range and (minn in var_data.meta and maxx in var_data.meta):
-                if len(str(int(var_data.meta[maxx]))) >= len(str(int(var_data.meta[minn]))):
+                if len(str(int(var_data.meta[maxx]))) >= len(
+                    str(int(var_data.meta[minn]))
+                ):
                     ln = str(int(var_data.meta[maxx]))
                 else:
                     ln = str(int(var_data.meta[minn]))
             if range and ln and range < 0:  # Cover all our bases:
                 range = None
             # Switch on Range
-            if range and ln and range <= 11:  # If range <= 11, we want 2 decimal places:
+            if (
+                range and ln and range <= 11
+            ):  # If range <= 11, we want 2 decimal places:
                 # Need extra for '.', and 3 decimal places (4 extra)
                 fmt = "F{}.3".format(len([i for i in ln]) + 4)
             elif range and ln and 11 < range <= 101:
@@ -898,7 +935,9 @@ class HERMESDataSchema:
             fmt = "A{}".format(len(var_data))
         else:
             raise ValueError(
-                "Couldn't find FORMAT for type {}".format(self.cdftypenames.get(cdftype, "UNKNOWN"))
+                "Couldn't find FORMAT for type {}".format(
+                    self.cdftypenames.get(cdftype, "UNKNOWN")
+                )
             )
         return fmt
 
@@ -917,7 +956,9 @@ class HERMESDataSchema:
         var_data = data.time
         times = len(var_data)
         if times < 2:
-            raise ValueError(f"Can not derive Time Resolution, need 2 samples, found {times}.")
+            raise ValueError(
+                f"Can not derive Time Resolution, need 2 samples, found {times}."
+            )
         # Calculate the Timedelta between two datetimes
         times = var_data.to_datetime()
         delta = times[1] - times[0]

--- a/hermes_core/util/schema.py
+++ b/hermes_core/util/schema.py
@@ -344,7 +344,8 @@ class HERMESDataSchema:
 
         return info
 
-    def check_well_formed(data):
+    @staticmethod
+    def _check_well_formed(data):
         """Checks if input data is well-formed, regular array
 
         Returns
@@ -413,7 +414,7 @@ class HERMESDataSchema:
         @raise ValueError: if L{data} has irregular dimensions
 
         """
-        d = HERMESDataSchema.check_well_formed(data)
+        d = HERMESDataSchema._check_well_formed(data)
         dims = d.shape
         elements = 1
         types = []

--- a/hermes_core/util/schema.py
+++ b/hermes_core/util/schema.py
@@ -464,7 +464,7 @@ class HERMESDataSchema:
                 for t in trytypes:
                     try:
                         newd = d.astype(dtype=t)
-                    except ValueError:  # Failure to cast, try next type
+                    except TypeError:  # Failure to cast, try next type
                         continue
                     if (newd == d).all():  # Values preserved, use this type
                         d = newd

--- a/hermes_core/util/schema.py
+++ b/hermes_core/util/schema.py
@@ -18,7 +18,7 @@ import hermes_core
 from hermes_core import log
 from hermes_core.util import util, const
 
-__all__ = ["HERMESDataSchema", "CDFSchema"]
+__all__ = ["HERMESDataSchema"]
 
 DEFAULT_GLOBAL_CDF_ATTRS_SCHEMA_FILE = "hermes_default_global_cdf_attrs_schema.yaml"
 DEFAULT_GLOBAL_CDF_ATTRS_FILE = "hermes_default_global_cdf_attrs.yaml"
@@ -217,12 +217,12 @@ class HERMESDataSchema:
         - description: (`str`) A brief description of the attribute
         - default: (`str`) The default value used if none is provided
         - derived: (`bool`) Whether the attibute can be derived by the HERMES
-            :py:class:`~hermes_core.util.schema.CDFSchema` class
+            :py:class:`~hermes_core.util.schema.HERMESDataSchema` class
         - required: (`bool`) Whether the attribute is required by HERMES standards
         - validate: (`bool`) Whether the attribute is included in the
             :py:func:`~hermes_core.util.validation.validate` checks (Note, not all attributes that
             are required are validated)
-        - overwrite: (`bool`) Whether the :py:class:`~hermes_core.util.schema.CDFSchema`
+        - overwrite: (`bool`) Whether the :py:class:`~hermes_core.util.schema.HERMESDataSchema`
             attribute derivations will overwrite an existing attribute value with an updated
             attribute value from the derivation process.
 
@@ -275,9 +275,9 @@ class HERMESDataSchema:
 
         - description: (`str`) A brief description of the attribute
         - derived: (`bool`) Whether the attibute can be derived by the HERMES
-            :py:class:`~hermes_core.util.schema.CDFSchema` class
+            :py:class:`~hermes_core.util.schema.HERMESDataSchema` class
         - required: (`bool`) Whether the attribute is required by HERMES standards
-        - overwrite: (`bool`) Whether the :py:class:`~hermes_core.util.schema.CDFSchema`
+        - overwrite: (`bool`) Whether the :py:class:`~hermes_core.util.schema.HERMESDataSchema`
             attribute derivations will overwrite an existing attribute value with an updated
             attribute value from the derivation process.
         - valid_values: (`str`) List of allowed values the attribute can take for HERMES products,
@@ -344,19 +344,12 @@ class HERMESDataSchema:
 
         return info
 
-
-class CDFSchema(HERMESDataSchema):
-    """Schema for CDF files."""
-
-    def __init__(self):
-        super().__init__()
-
     def check_well_formed(data):
         """Checks if input data is well-formed, regular array
 
         Returns
         -------
-        :class:`~numpy.ndarray`
+        :class:`~numpy.ndarray`s
             The input data as a well-formed array; may be the input
             data exactly.
         """
@@ -420,7 +413,7 @@ class CDFSchema(HERMESDataSchema):
         @raise ValueError: if L{data} has irregular dimensions
 
         """
-        d = CDFSchema.check_well_formed(data)
+        d = HERMESDataSchema.check_well_formed(data)
         dims = d.shape
         elements = 1
         types = []
@@ -1346,33 +1339,3 @@ class CDFSchema(HERMESDataSchema):
         else:
             instr_mode = data.meta["Instrument_mode"]
         return instr_mode.lower()  # Makse sure its all lowercase
-
-
-class NetCDFSchema(HERMESDataSchema):
-    """Schema for NetCDF files."""
-
-    @property
-    def global_attribute_schema(self):
-        """Schema for global attributes of the file."""
-        return {
-            "attribute1": {"type": "string", "required": True},
-            "attribute2": {"type": "int", "required": False},
-            # Define more global attributes and their schemas
-        }
-
-    @property
-    def variable_attribute_schema(self):
-        """Schema for variable attributes of the file."""
-        return {
-            "variable1": {
-                "attribute1": {"type": "float", "required": True},
-                "attribute2": {"type": "string", "required": False},
-                # Define more attributes for variable1 and their schemas
-            },
-            "variable2": {
-                "attribute1": {"type": "int", "required": True},
-                "attribute2": {"type": "string", "required": False},
-                # Define more attributes for variable2 and their schemas
-            },
-            # Define more variables and their attribute schemas
-        }

--- a/hermes_core/util/tests/test_schema.py
+++ b/hermes_core/util/tests/test_schema.py
@@ -1,10 +1,22 @@
 import pytest
+import tempfile
+import yaml
+import datetime
 from collections import OrderedDict
+import numpy as np
+from numpy.random import random
+from astropy.time import Time
+from astropy.timeseries import TimeSeries
 from astropy.table import Table
+import astropy.units as u
+from spacepy.pycdf import CDF
+from hermes_core.timedata import TimeData
 from hermes_core.util.schema import HERMESDataSchema
+from hermes_core.util import const
 
 
 def test_hermes_data_schema():
+    """Test Schema Template and Info Functions"""
     schema = HERMESDataSchema()
 
     # Global Attribute Schema
@@ -42,3 +54,296 @@ def test_hermes_data_schema():
     )
     with pytest.raises(KeyError):
         _ = schema.measurement_attribute_info(attribute_name="NotAnAttribute")
+
+
+def test_load_yaml_data():
+    """Test Loading Yaml Data for Schema Files"""
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # This function writes invalid YAML content into a file
+        invalid_yaml = """
+        name: John Doe
+        age 30
+        """
+
+        with open(tmpdirname + "test.yaml", "w") as file:
+            file.write(invalid_yaml)
+
+        # Load from an non-existant file
+        yaml_data = HERMESDataSchema._load_yaml_data(tmpdirname + "test.yaml")
+        assert yaml_data == {}
+
+
+def test_check_well_formed():
+    """Test that the Data can be output to CDF"""
+
+    # Badly Shaped Data
+    data = [np.array([1, 2, 3]), np.array([[4, 5], [6, 7]])]
+    with pytest.raises(ValueError):
+        _ = HERMESDataSchema._check_well_formed(data)
+
+    # Empty Data
+    data = np.array([], dtype=object)
+    d = HERMESDataSchema._check_well_formed(data)
+    assert len(d) == 0
+
+    # Badly Shaped Object
+    data = np.array([np.array([1, 2, 3]), np.array([[4, 5], [6, 7]])], dtype=object)
+    with pytest.raises(ValueError):
+        _ = HERMESDataSchema._check_well_formed(data)
+
+
+def test_types():
+    """Function to test getting the CDF data types for different data types"""
+
+    # String Type
+    _, types, _ = HERMESDataSchema()._types("")
+    assert types == [51, 52]
+
+    # Time Types
+    # data = np.array(
+    #     ["2023-08-03T10:20:30.123456789", "2023-08-03T15:30:45.678901234"], dtype="datetime64[ns]"
+    # )
+    # _, types, _ = HERMESDataSchema()._types(data)
+    # assert types == [const.CDF_TIME_TT2000, const.CDF_EPOCH16, const.CDF_EPOCH]
+
+
+def test_type_guessing():
+    """Guess CDF types based on input data"""
+    samples = [
+        [1, 2, 3, 4],
+        [[1.2, 1.3, 1.4], [2.2, 2.3, 2.4]],
+        ["hello", "there", "everybody"],
+        datetime.datetime(2009, 1, 1),
+        datetime.datetime(2009, 1, 1, 12, 15, 12, 1000),
+        datetime.datetime(2009, 1, 1, 12, 15, 12, 1),
+        [1.0],
+        0.0,
+        np.array([1, 2, 3], dtype=np.int32),
+        np.array([1, 2, 4], dtype=np.float64),
+        np.array([1, 2, 5], dtype=np.int64),
+        2**62,
+        -1.0,
+        np.array([1, 2, 6], dtype="<u2"),
+        np.array([1, 2, 7], dtype=">u2"),
+        np.int64(-1 * 2**63),
+        np.int32(-1 * 2**31),
+        -1 * 2**31,
+        np.array([5, 6, 7], dtype=np.uint8),
+        [4611686018427387904],
+        np.array([1], dtype=object),
+        ["\U0001f600\U0001f600"],
+    ]
+    types = [
+        (
+            (4,),
+            [
+                const.CDF_BYTE,
+                const.CDF_INT1,
+                const.CDF_UINT1,
+                const.CDF_INT2,
+                const.CDF_UINT2,
+                const.CDF_INT4,
+                const.CDF_UINT4,
+                const.CDF_INT8,
+                const.CDF_FLOAT,
+                const.CDF_REAL4,
+                const.CDF_DOUBLE,
+                const.CDF_REAL8,
+            ],
+            1,
+        ),
+        (
+            (2, 3),
+            [const.CDF_FLOAT, const.CDF_REAL4, const.CDF_DOUBLE, const.CDF_REAL8],
+            1,
+        ),
+        ((3,), [const.CDF_CHAR, const.CDF_UCHAR], 9),
+        ((), [const.CDF_TIME_TT2000, const.CDF_EPOCH, const.CDF_EPOCH16], 1),
+        ((), [const.CDF_TIME_TT2000, const.CDF_EPOCH, const.CDF_EPOCH16], 1),
+        ((), [const.CDF_TIME_TT2000, const.CDF_EPOCH16, const.CDF_EPOCH], 1),
+        (
+            (1,),
+            [const.CDF_FLOAT, const.CDF_REAL4, const.CDF_DOUBLE, const.CDF_REAL8],
+            1,
+        ),
+        ((), [const.CDF_FLOAT, const.CDF_REAL4, const.CDF_DOUBLE, const.CDF_REAL8], 1),
+        ((3,), [const.CDF_INT4], 1),
+        ((3,), [const.CDF_DOUBLE, const.CDF_REAL8], 1),
+        ((3,), [const.CDF_INT8], 1),
+        (
+            (),
+            [
+                const.CDF_INT8,
+                const.CDF_FLOAT,
+                const.CDF_REAL4,
+                const.CDF_DOUBLE,
+                const.CDF_REAL8,
+            ],
+            1,
+        ),
+        ((), [const.CDF_FLOAT, const.CDF_REAL4, const.CDF_DOUBLE, const.CDF_REAL8], 1),
+        ((3,), [const.CDF_UINT2], 1),
+        ((3,), [const.CDF_UINT2], 1),
+        ((), [const.CDF_INT8], 1),
+        ((), [const.CDF_INT4], 1),
+        (
+            (),
+            [
+                const.CDF_INT4,
+                const.CDF_INT8,
+                const.CDF_FLOAT,
+                const.CDF_REAL4,
+                const.CDF_DOUBLE,
+                const.CDF_REAL8,
+            ],
+            1,
+        ),
+        ((3,), [const.CDF_UINT1, const.CDF_UCHAR], 1),
+        (
+            (1,),
+            [
+                const.CDF_INT8,
+                const.CDF_FLOAT,
+                const.CDF_REAL4,
+                const.CDF_DOUBLE,
+                const.CDF_REAL8,
+            ],
+            1,
+        ),
+        (
+            (1,),
+            [
+                const.CDF_BYTE,
+                const.CDF_INT1,
+                const.CDF_UINT1,
+                const.CDF_INT2,
+                const.CDF_UINT2,
+                const.CDF_INT4,
+                const.CDF_UINT4,
+                const.CDF_INT8,
+                const.CDF_FLOAT,
+                const.CDF_REAL4,
+                const.CDF_DOUBLE,
+                const.CDF_REAL8,
+            ],
+            1,
+        ),
+        ((1,), [const.CDF_CHAR, const.CDF_UCHAR], 8),
+    ]
+    with pytest.raises(ValueError):
+        HERMESDataSchema()._types([object()])
+    for s, t in zip(samples, types):
+        t = (t[0], [i.value for i in t[1]], t[2])
+        assert t == HERMESDataSchema()._types(s)
+
+
+def test_min_max_none():
+    """Get min/max values for None types"""
+    with pytest.raises(ValueError):
+        HERMESDataSchema()._get_minmax(None)
+
+
+def test_min_max_unknown():
+    """Get min/max values for unknown types"""
+    with pytest.raises(ValueError):
+        HERMESDataSchema()._get_minmax("unknown_type")
+
+
+def test_min_max_TT2000():
+    """Get min/max values for TT2000 types"""
+    minval, maxval = HERMESDataSchema()._get_minmax(const.CDF_TIME_TT2000)
+    # Make sure the minimum isn't just plain invalid
+    assert minval == datetime.datetime(1, 1, 1)
+    assert maxval == datetime.datetime(2292, 4, 11, 11, 46, 7, 670776)
+
+
+def test_min_max_Epoch16():
+    """Get min/max values for Epoch16 types"""
+    minval, maxval = HERMESDataSchema()._get_minmax(const.CDF_EPOCH16)
+    # Make sure the minimum isn't just plain invalid
+    assert minval == datetime.datetime(1, 1, 1)
+    assert maxval == datetime.datetime(9999, 12, 31, 23, 59, 59)
+
+
+def test_min_max_Epoch():
+    """Get min/max values for EPOCH types"""
+    minval, maxval = HERMESDataSchema()._get_minmax(const.CDF_EPOCH)
+    # Make sure the minimum isn't just plain invalid
+    assert minval == datetime.datetime(1, 1, 1)
+    assert maxval == datetime.datetime(9999, 12, 31, 23, 59, 59)
+
+
+def test_min_max_Float():
+    """Get min/max values for a float"""
+    minval, maxval = HERMESDataSchema()._get_minmax(const.CDF_FLOAT)
+    np.allclose(-3.4028234663853e38, minval)
+    np.allclose(3.4028234663853e38, maxval)
+
+
+def test_min_max_Int():
+    """Get min/max values for an integer"""
+    minval, maxval = HERMESDataSchema()._get_minmax(const.CDF_INT1)
+    assert -128 == minval
+    assert 127 == maxval
+
+
+def test_format():
+    """Set the format"""
+    # This is done by: type, expected, validmin, validmax (None okay)
+    expected = (
+        (const.CDF_EPOCH.value, "A24", None, None),
+        (const.CDF_EPOCH16.value, "A36", None, None),
+        (const.CDF_TIME_TT2000.value, "A29", None, None),
+        (const.CDF_INT2.value, "I2", -2, 9),
+        (const.CDF_UINT2.value, "I5", None, None),
+        (const.CDF_INT2.value, "I6", None, None),
+        (const.CDF_UINT2.value, "I2", 0, 10),
+        (const.CDF_FLOAT.value, "F6.3", 1, 10),
+        (const.CDF_FLOAT.value, "F6.2", 1, 100),
+        (const.CDF_FLOAT.value, "F6.1", 1, 1000),
+        (const.CDF_FLOAT.value, "G10.2E3", 1, -1),
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        cdf = CDF(tmpdirname + "test.cdf", create=True)
+
+        for t, e, vmin, vmax in expected:
+            v = cdf.new("var", type=t)
+            print(v)
+            if vmin is not None:
+                v.attrs["VALIDMIN"] = vmin
+            if vmin is not None:
+                v.attrs["VALIDMAX"] = vmax
+            format = HERMESDataSchema()._format_helper(cdf, "var", t)
+            assert e == format
+            del cdf["var"]
+
+        # Test Format Char
+        v = cdf.new("var", data=["hi", "there"])
+        format = HERMESDataSchema()._format_helper(cdf, "var", const.CDF_CHAR.value)
+        assert "A2" == format
+
+
+def test_resolution():
+    """Test Time Resolution"""
+    ts = TimeSeries()
+    # Create an astropy.Time object
+    time = np.arange(1)
+    time_col = Time(time, format="unix")
+    ts["time"] = time_col
+    ts["time"].meta = OrderedDict({"CATDESC": "Epoch Time"})
+
+    # Add Measurement
+    quant = u.Quantity(value=random(size=(1)), unit="m", dtype=np.uint16)
+    ts["measurement"] = quant
+    ts["measurement"].meta = OrderedDict(
+        {
+            "VAR_TYPE": "data",
+            "CATDESC": "Test Data",
+        }
+    )
+    template = TimeData.global_attribute_template("eea", "l2", "0.0.0")
+
+    # Get Resolution
+    with pytest.raises(ValueError):
+        td = TimeData(data=ts, meta=template)

--- a/hermes_core/util/tests/test_schema.py
+++ b/hermes_core/util/tests/test_schema.py
@@ -334,7 +334,6 @@ def test_format():
 
         for t, e, vmin, vmax in expected:
             v = cdf.new("var", type=t)
-            print(v)
             if vmin is not None:
                 v.attrs["VALIDMIN"] = vmin
             if vmin is not None:

--- a/hermes_core/util/tests/test_validation.py
+++ b/hermes_core/util/tests/test_validation.py
@@ -1,0 +1,116 @@
+from collections import OrderedDict
+from pathlib import Path
+import pytest
+import tempfile
+import numpy as np
+from numpy.random import random
+from astropy.time import Time
+from astropy.timeseries import TimeSeries
+import astropy.units as u
+from spacepy.pycdf import CDF
+import hermes_core
+from hermes_core.timedata import TimeData
+from hermes_core.util.schema import HERMESDataSchema
+from hermes_core.util.validation import validate
+
+SAMPLE_CDF_FILE = "hermes_nms_default_l1_20160322_123031_v0.0.1.cdf"
+
+
+def get_test_timeseries():
+    ts = TimeSeries()
+
+    # Create an astropy.Time object
+    time = np.arange(10)
+    time_col = Time(time, format="unix")
+    ts["time"] = time_col
+
+    # Add Measurement
+    quant = u.Quantity(value=random(size=(10)), unit="m", dtype=np.uint16)
+    ts["measurement"] = quant
+    ts["measurement"].meta = OrderedDict(
+        {
+            "VAR_TYPE": "metadata",
+            "CATDESC": "Test Metadata",
+        }
+    )
+    return ts
+
+
+def test_valid_cdf():
+    """Function to Test Validation of a Valid Sample CDF File"""
+    valid_cdf_path = str(
+        Path(hermes_core.__file__).parent
+        / "data"
+        / "sample"
+        / "hermes_nms_default_l1_20160322_123031_v0.0.1.cdf"
+    )
+
+    result = validate(valid_cdf_path)
+    assert len(result) <= 1  # TODO Logical Source and File ID Do not Agree
+
+
+def test_non_cdf_file():
+    """Function to Test a file using the CDFValidator that is not a CDF File"""
+    invlid_path = str(Path(hermes_core.__file__).parent / "data" / "README.rst")
+    with pytest.raises(ValueError):
+        _ = validate(invlid_path)
+
+
+def test_non_existant_file():
+    """Function to Test a file using the CDFValidator that does not exist"""
+    invlid_path = str(Path(hermes_core.__file__).parent / "data" / "test.cdf")
+    result = validate(invlid_path)
+    assert len(result) == 1
+    assert "Could not open CDF File at path:" in result[0]
+
+
+def test_missing_global_attrs():
+    """Function to ensure missing global attributes are reported in validation"""
+
+    # Create a Test TimeData
+    ts = get_test_timeseries()
+    template = TimeData.global_attribute_template("eea", "l2", "0.0.0")
+    td = TimeData(data=ts, meta=template)
+
+    # Convert to a CDF File and Validate
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        out_file = td.save(tmpdirname)
+
+        with CDF(out_file, readonly=False) as cdf:
+            del cdf.meta["Descriptor"]
+
+        # Validate
+        result = validate(out_file)
+        assert (
+            "Required attribute (Descriptor) not present in global attributes."
+            in result
+        )
+        assert "Required attribute (DOI) not present in global attributes." in result
+
+
+def test_missing_var_type():
+    """Function to ensure missing global attributes are reported in validation"""
+
+    # Create a Test TimeData
+    ts = get_test_timeseries()
+    template = TimeData.global_attribute_template("eea", "l2", "0.0.0")
+    td = TimeData(data=ts, meta=template)
+
+    # Convert to a CDF File and Validate
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        out_file = td.save(tmpdirname)
+
+        with CDF(out_file, readonly=False) as cdf:
+            del cdf["measurement"].meta["VAR_TYPE"]
+
+        # Validate
+        result = validate(out_file)
+        assert (
+            "Variable: measurement missing 'VAR_TYPE' attribute. Cannot Validate Variable."
+            in result
+        )
+
+
+# attrs = HERMESDataSchema.global_attribute_info()
+# attrs = attrs[(attrs["required"]==True) & (attrs["default"]==None) & (attrs["derived"]==False)]["Attribute"].tolist()
+# attrs = list(filter(lambda attr_name: attr_name not in ["Descriptor", "Data_level", "Data_version"], attrs))

--- a/hermes_core/util/validation.py
+++ b/hermes_core/util/validation.py
@@ -180,10 +180,7 @@ class CDFValidator(TimeDataValidator):
             # If it is a required attribute and not present
             if attr_schema["required"] and attr_name not in var_data.attrs:
                 # Check to see if there is an "alternate" attribute
-                if (
-                    "alternate" not in attr_schema
-                    and attr_schema["alternate"] is not None
-                ):
+                if attr_schema["alternate"] is None:
                     variable_errors.append(
                         f"Variable: {var_name} missing '{attr_name}' attribute."
                     )

--- a/hermes_core/util/validation.py
+++ b/hermes_core/util/validation.py
@@ -227,8 +227,8 @@ class CDFValidator(TimeDataValidator):
         # Save the Current Format
         variable_format = cdf_file[var_name].meta["FORMAT"]
         # Get the target Format for the Variable
-        target_format = self.schema._format_helper(
-            data=cdf_file, var_name=var_name, cdftype=cdf_file[var_name].type()
+        target_format = self.schema._get_format(
+            var_data=cdf_file[var_name], cdftype=cdf_file[var_name].type()
         )
 
         if variable_format != target_format:

--- a/hermes_core/util/validation.py
+++ b/hermes_core/util/validation.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 from abc import ABC, abstractmethod
-from spacepy.pycdf import CDF
+from spacepy.pycdf import CDF, CDFError
 from spacepy.pycdf.istp import FileChecks, VariableChecks
-from hermes_core.util.schema import CDFSchema
+from hermes_core.util.schema import HERMESDataSchema
 
 __all__ = ["validate", "CDFValidator"]
 
@@ -27,8 +27,6 @@ def validate(filepath):
     # Create the appropriate validator object based on file type
     if file_extension == ".cdf":
         validator = CDFValidator()
-    elif file_extension == ".nc":
-        validator = NetCDFValidator()
     else:
         raise ValueError(f"Unsupported file type: {file_extension}")
 
@@ -68,7 +66,7 @@ class CDFValidator(TimeDataValidator):
         super().__init__()
 
         # CDF Schema
-        self.schema = CDFSchema()
+        self.schema = HERMESDataSchema()
 
     def validate(self, file_path):
         """
@@ -89,7 +87,7 @@ class CDFValidator(TimeDataValidator):
 
         try:
             # Open CDF file with context manager
-            with CDF(file_path) as cdf_file:
+            with CDF(file_path, readonly=True) as cdf_file:
                 # Verify that all `required` global attributes in the schema are present
                 global_attr_validation_errors = self._validate_global_attr_schema(
                     cdf_file=cdf_file
@@ -106,7 +104,7 @@ class CDFValidator(TimeDataValidator):
                 file_checks_errors = self._file_checks(cdf_file=cdf_file)
                 validation_errors.extend(file_checks_errors)
 
-        except IOError:
+        except CDFError:
             validation_errors.append(f"Could not open CDF File at path: {file_path}")
 
         return validation_errors
@@ -121,6 +119,18 @@ class CDFValidator(TimeDataValidator):
         for attr_name, attr_schema in self.schema.global_attribute_schema.items():
             # If it is a required attribute and not present
             if attr_schema["validate"] and (attr_name not in cdf_file.attrs):
+                global_attr_validation_errors.append(
+                    f"Required attribute ({attr_name}) not present in global attributes.",
+                )
+            # If it is a required attribute but null
+            if (
+                attr_schema["validate"]
+                and (attr_name in cdf_file.attrs)
+                and (
+                    (cdf_file.attrs[attr_name][0] == "")
+                    or (cdf_file.attrs[attr_name][0] is None)
+                )
+            ):
                 global_attr_validation_errors.append(
                     f"Required attribute ({attr_name}) not present in global attributes.",
                 )
@@ -298,26 +308,3 @@ class CDFValidator(TimeDataValidator):
                 )
 
         return variable_checks_errors
-
-
-class NetCDFValidator(TimeDataValidator):
-    """
-    Validator for NetCDF files.
-    """
-
-    def validate(self, file_path):
-        """
-        Validate the NetCDF file.
-
-        Parameters
-        ----------
-        file_path : `str`
-            The path to the NetCDF file.
-
-        Returns
-        -------
-        errors : `list[str]`
-            A list of validation errors returned. A valid file will result in an emppty list being returned.
-        """
-        # Validation logic for NetCDF files
-        pass


### PR DESCRIPTION
This PR removes unused code and refactors the HERMES data schema architecture. Rather than having a "schema" for each file type of CDF, NetCDF, and potentially JSON and CSV, this introduces a single `HERMESDataSchema` class that can derive metadata for all file types. This PR also refactors functions in `schema.py` to be easier to unit test and adds coverage for these functions. 

* Remove NetCDF I/O
* Remove NetCDF Schema
* Consolidate CDFSchema to HERMESDataSchema
* Started adding tests to increase validation coverage