### PR TITLE
Provide TimeData Container Structures for Support and NRV Data

### DIFF
--- a/docs/user-guide/cdf_format_guide.rst
+++ b/docs/user-guide/cdf_format_guide.rst
@@ -483,6 +483,7 @@ convenience.
 * FIELDNAM
 * FILLVAL (if time varying)
 * FORMAT/FORM_PTR
+* LABLAXIS or LABL_PTR_i
 * SI_CONVERSION
 * UNITS/UNIT_PTR
 * VALIDMIN (if time varying)

--- a/docs/user-guide/reading_writing_data.rst
+++ b/docs/user-guide/reading_writing_data.rst
@@ -62,7 +62,7 @@ You can also create your time array directly
 Note the use of `~astropy.time` and `astropy.units` which provide several advantages over using arrays of numbers and are required by :py:class:`~hermes_core.timedata.TimeData`.
 
 Next create a `dict` or `~collections.OrderedDict` containing the required CDF global metadata.
-The class function :py:func:`~hermes_core.timedata.TimeData.global_attribute_template`:: will provide you an empty version that you can fill in if needed.
+The class function :py:func:`~hermes_core.timedata.TimeData.global_attribute_template` will provide you an empty version that you can fill in.
 Here is an example with filled in values.
 
     >>> input_attrs = {
@@ -105,13 +105,14 @@ You can now create the :py:class:`~hermes_core.timedata.TimeData` object,
     >>> from hermes_core.timedata import TimeData
     >>> timedata = TimeData(data=ts, meta=input_attrs)
 
-The :py:class:`~hermes_core.timedata.TimeData` object also accepts optional arguments for loading
-non-record-varying (NRV) support data. These arguments are required to be a `dict`
-of :py:class:`~astropy.nddata.NDData` objects.
+The :py:class:`~hermes_core.timedata.TimeData` object also accepts additional arbitrary data arrays, 
+so-called non-record-varying (NRV) data, which is frequently support data. These data are required to be a `dict`
+of :py:class:`~astropy.nddata.NDData` objects which are data containers for physical data.
+A guide to the `~astropy.nddata` package is available in the `astropy documentation <https://docs.astropy.org/en/stable/nddata/>`_.
 
     >>> from astropy.nddata import NDData
-    >>> support = {"const_param": NDData(data=[1e-3])}
-    >>> timedata = TimeData(data=ts, meta=input_attrs, support=support)
+    >>> support_data = {"const_param": NDData(data=[1e-3])}
+    >>> timedata = TimeData(data=ts, meta=input_attrs, support=support_data)
 
 The :py:class:`~hermes_core.timedata.TimeData` is mutable so you can edit it, add another measurement column or edit the metadata after the fact.
 Your variable metadata can be found by querying the measurement column directly.
@@ -148,10 +149,10 @@ The :py:class:`~hermes_core.timedata.TimeData` can the be updated, measurements 
 Adding data to a ``TimeData`` Container
 =======================================
 
-A new column of data, support data, or NRV data can be added to an existing instance. Remember 
-that new data measurements must have the same time stamps as the existing ones and therefore 
-the same number of entries. Support data and non-record-varying data can be added as needed.
-You can add the new column in one of two ways.
+A new set of measurements or support data can be added to an existing instance. Remember 
+that new measurements must have the same time stamps as the existing ones and therefore 
+the same number of entries. Support data can be added as needed.
+You can add the new measurments in one of two ways.
 
 The more explicit approach is to use :py:func:`~hermes_core.timedata.TimeData.add_measurement` function::
 
@@ -162,16 +163,16 @@ Or you can add the measurement data directly.
 
     >>> timedata["By"] = u.Quantity(np.arange(len(timedata['Bx'])), 'Gauss', dtype=np.uint16)
 
-Remember that you'll then have to fill in the variable's metadata attributes afterwards.
+Remember that you'll then have to provide the measurement metadata attributes.
 
     >>> timedata['By'].meta.update(measure_meta) # doctest: +SKIP
     
-To add non-time-varying support data use the :py:func:`~hermes_core.timedata.TimeData.add_support` function::
+To add support data use the :py:func:`~hermes_core.timedata.TimeData.add_support` function::
 
     >>> timedata.add_support(
     ...     name="Calibration_const",
     ...     data=NDData(data=[1e-1]),
-    ...     meta={"CATDESC": "Calibration Factor", "VAR_TYPE": "metadata"},
+    ...     meta={"CATDESC": "Calibration Factor", "VAR_TYPE": "support_data"},
     ... )
 
 Adding metadata attributes

--- a/docs/user-guide/reading_writing_data.rst
+++ b/docs/user-guide/reading_writing_data.rst
@@ -106,12 +106,12 @@ You can now create the :py:class:`~hermes_core.timedata.TimeData` object,
     >>> timedata = TimeData(data=ts, meta=input_attrs)
 
 The :py:class:`~hermes_core.timedata.TimeData` object also accepts optional arguments for loading
-non-record-varying (NRV) data. These arguments are required to be a `dict`
+non-record-varying (NRV) support data. These arguments are required to be a `dict`
 of :py:class:`~astropy.nddata.NDData` objects.
 
     >>> from astropy.nddata import NDData
-    >>> nrv_data = {"const_param": NDData(data=[1e-3])}
-    >>> timedata = TimeData(data=ts, meta=input_attrs, nrv_data=nrv_data)
+    >>> support = {"const_param": NDData(data=[1e-3])}
+    >>> timedata = TimeData(data=ts, meta=input_attrs, support=support)
 
 The :py:class:`~hermes_core.timedata.TimeData` is mutable so you can edit it, add another measurement column or edit the metadata after the fact.
 Your variable metadata can be found by querying the measurement column directly.
@@ -152,19 +152,27 @@ A new column of data, support data, or NRV data can be added to an existing inst
 that new data measurements must have the same time stamps as the existing ones and therefore 
 the same number of entries. Support data and non-record-varying data can be added as needed.
 You can add the new column in one of two ways.
+
 The more explicit approach is to use :py:func:`~hermes_core.timedata.TimeData.add_measurement` function::
 
     >>> data = u.Quantity(np.arange(len(timedata['Bx'])), 'Gauss', dtype=np.uint16)
     >>> timedata.add_measurement(measure_name="By", data=data, meta={"CATDESC": "Test Metadata"})
 
-Or you can add the measurement data, or NRV data directly.
+Or you can add the measurement data directly.
 
     >>> timedata["By"] = u.Quantity(np.arange(len(timedata['Bx'])), 'Gauss', dtype=np.uint16)
-    >>> timedata["calibration_const"] = NDData(data=[1e-3])
 
 Remember that you'll then have to fill in the variable's metadata attributes afterwards.
 
     >>> timedata['By'].meta.update(measure_meta) # doctest: +SKIP
+    
+To add non-time-varying support data use the :py:func:`~hermes_core.timedata.TimeData.add_support` function::
+
+    >>> timedata.add_support(
+    ...     name="Calibration_const",
+    ...     data=NDData(data=[1e-1]),
+    ...     meta={"CATDESC": "Calibration Factor", "VAR_TYPE": "metadata"},
+    ... )
 
 Adding metadata attributes
 ==========================

--- a/docs/user-guide/reading_writing_data.rst
+++ b/docs/user-guide/reading_writing_data.rst
@@ -105,6 +105,14 @@ You can now create the :py:class:`~hermes_core.timedata.TimeData` object,
     >>> from hermes_core.timedata import TimeData
     >>> timedata = TimeData(data=ts, meta=input_attrs)
 
+The :py:class:`~hermes_core.timedata.TimeData` object also accepts optional arguments for loading
+non-record-varying (NRV) data. These arguments are required to be a `dict`
+of :py:class:`~astropy.nddata.NDData` objects.
+
+    >>> from astropy.nddata import NDData
+    >>> nrv_data = {"const_param": NDData(data=[1e-3])}
+    >>> timedata = TimeData(data=ts, meta=input_attrs, nrv_data=nrv_data)
+
 The :py:class:`~hermes_core.timedata.TimeData` is mutable so you can edit it, add another measurement column or edit the metadata after the fact.
 Your variable metadata can be found by querying the measurement column directly.
 
@@ -140,19 +148,21 @@ The :py:class:`~hermes_core.timedata.TimeData` can the be updated, measurements 
 Adding data to a ``TimeData`` Container
 =======================================
 
-A new column of data can be added to an existing instance.
-Remember that these new measurements must have the same time stamps as the existing ones and therefore the same number of measurements.
+A new column of data, support data, or NRV data can be added to an existing instance. Remember 
+that new data measurements must have the same time stamps as the existing ones and therefore 
+the same number of entries. Support data and non-record-varying data can be added as needed.
 You can add the new column in one of two ways.
 The more explicit approach is to use :py:func:`~hermes_core.timedata.TimeData.add_measurement` function::
 
     >>> data = u.Quantity(np.arange(len(timedata['Bx'])), 'Gauss', dtype=np.uint16)
     >>> timedata.add_measurement(measure_name="By", data=data, meta={"CATDESC": "Test Metadata"})
 
-Or you can just add the column directly.
+Or you can add the measurement data, or NRV data directly.
 
     >>> timedata["By"] = u.Quantity(np.arange(len(timedata['Bx'])), 'Gauss', dtype=np.uint16)
+    >>> timedata["calibration_const"] = NDData(data=[1e-3])
 
-Remember that you'll then have to fill in the meta data afterwards.
+Remember that you'll then have to fill in the variable's metadata attributes afterwards.
 
     >>> timedata['By'].meta.update(measure_meta) # doctest: +SKIP
 

--- a/hermes_core/data/hermes_default_variable_cdf_attrs_schema.yaml
+++ b/hermes_core/data/hermes_default_variable_cdf_attrs_schema.yaml
@@ -362,6 +362,7 @@ support_data:
   - FIELDNAM
   - FILLVAL
   - FORMAT
+  - LABLAXIS
   - SI_CONVERSION
   - UNITS
   - VALIDMIN
@@ -370,5 +371,6 @@ support_data:
 metadata:
   - CATDESC
   - FIELDNAM
+  - FILLVAL
   - FORMAT
   - VAR_TYPE

--- a/hermes_core/tests/test_timedata.py
+++ b/hermes_core/tests/test_timedata.py
@@ -282,7 +282,7 @@ def test_timedata_add_measurement():
     test_data.add_measurement(measure_name="test", data=q)
     assert test_data["test"].shape == (10,)
 
-    # Add Dimensionless Record-Varying Data
+    # Add Dimensionless measurements (or Record-Varying) Data
     q = Quantity(value=random(size=(10)), unit=u.dimensionless_unscaled)
     test_data.add_measurement(
         measure_name="Test Dimensionless",
@@ -323,7 +323,7 @@ def test_timedata_add_support():
     # Initialize a CDF File Wrapper
     test_data = TimeData(ts, meta=input_attrs)
 
-    # Add non-Quantity
+    # Add non-NDData
     with pytest.raises(TypeError):
         test_data.add_support(name="test", data=[], meta={})
 

--- a/hermes_core/timedata.py
+++ b/hermes_core/timedata.py
@@ -105,9 +105,9 @@ class TimeData:
 
         # Copy the Non-Record Varying Data
         if support:
-            self.support = support
+            self._support = support
         else:
-            self.support = {}
+            self._support = {}
 
         # Derive Metadata
         self.schema = HERMESDataSchema()
@@ -119,6 +119,13 @@ class TimeData:
         (`astropy.timeseries.TimeSeries`) A `TimeSeries` representing one or more measurements as a function of time.
         """
         return self._data
+
+    @property
+    def support(self):
+        """
+        (`dict[astropy.nddata.NDData]`) A `dict` containing one or more non-time-varying support variables.
+        """
+        return self._support
 
     @property
     def meta(self):
@@ -333,9 +340,9 @@ class TimeData:
                 )
 
         # Support/ Non-Record-Varying Data
-        for col in self.support:
+        for col in self._support:
             for attr_name, attr_value in self.schema.derive_measurement_attributes(
-                self.support, col
+                self._support, col
             ).items():
                 self._update_support_attribute(
                     var_name=col, attr_name=attr_name, attr_value=attr_value
@@ -380,22 +387,22 @@ class TimeData:
 
     def _update_support_attribute(self, var_name, attr_name, attr_value):
         if (
-            attr_name in self.support[var_name].meta
-            and self.support[var_name].meta[attr_name] is not None
+            attr_name in self._support[var_name].meta
+            and self._support[var_name].meta[attr_name] is not None
         ):
             attr_schema = self.schema.variable_attribute_schema["attribute_key"][
                 attr_name
             ]
             if (
-                self.support[var_name].meta[attr_name] != attr_value
+                self._support[var_name].meta[attr_name] != attr_value
                 and attr_schema["overwrite"]
             ):
                 warn_user(
-                    f"Overiding {var_name} Attribute {attr_name} : {self.support[var_name].meta[attr_name]} -> {attr_value}"
+                    f"Overiding {var_name} Attribute {attr_name} : {self._support[var_name].meta[attr_name]} -> {attr_value}"
                 )
-                self.support[var_name].meta[attr_name] = attr_value
+                self._support[var_name].meta[attr_name] = attr_value
         else:
-            self.support[var_name].meta[attr_name] = attr_value
+            self._support[var_name].meta[attr_name] = attr_value
 
     def add_measurement(self, measure_name: str, data: u.Quantity, meta: dict = None):
         """
@@ -457,10 +464,10 @@ class TimeData:
         if not isinstance(data, NDData):
             raise TypeError(f"Measurement {name} must be type `astropy.nddata.NDData`.")
 
-        self.support[name] = data
+        self._support[name] = data
         # Add any Metadata Passed not in the NDData
         if meta:
-            self.support[name].meta.update(meta)
+            self._support[name].meta.update(meta)
 
         # Derive Metadata Attributes for the Measurement
         self._derive_metadata()
@@ -476,8 +483,8 @@ class TimeData:
         """
         if measure_name in self._data.columns:
             self._data.remove_column(measure_name)
-        elif measure_name in self.support:
-            self.support.pop(measure_name)
+        elif measure_name in self._support:
+            self._support.pop(measure_name)
         else:
             raise ValueError(f"Data for Measurement {measure_name} not found.")
 

--- a/hermes_core/timedata.py
+++ b/hermes_core/timedata.py
@@ -28,7 +28,7 @@ class TimeData:
     data :  `astropy.timeseries.TimeSeries`
         The time series of data. Columns must be `~astropy.units.Quantity` arrays.
     support : `dict[astropy.nddata.NDData]`, optional
-        Non-Record-Varying data associated with the timeseries data.
+        Support data arrays which do not vary with time (i.e. Non-Record-Varying data).
     meta : `dict`, optional
         The metadata describing the time series in an ISTP-compliant format.
 
@@ -78,10 +78,10 @@ class TimeData:
 
         # Check NRV Data
         if support:
-            for colname in support:
-                if not (isinstance(support[colname], NDData)):
+            for key in support:
+                if not (isinstance(support[key], NDData)):
                     raise TypeError(
-                        f"Variable '{colname}' must be an astropy.nddata.NDData object"
+                        f"Variable '{key}' must be an astropy.nddata.NDData object"
                     )
 
         # Copy the TimeSeries
@@ -406,7 +406,7 @@ class TimeData:
 
     def add_measurement(self, measure_name: str, data: u.Quantity, meta: dict = None):
         """
-        Add a new time-varying measurement (column).
+        Add a new column of time-varying measurements.
 
         Parameters
         ----------
@@ -420,6 +420,7 @@ class TimeData:
         Raises
         ------
         TypeError: If var_data is not of type Quantity.
+        ValueError: If data has more than one dimension
         """
         # Verify that all Measurements are `Quantity`
         if (not isinstance(data, u.Quantity)) or (not data.unit):
@@ -445,16 +446,16 @@ class TimeData:
 
     def add_support(self, name: str, data: NDData, meta: dict = None):
         """
-        Add a new non-time-varying measurement (column).
+        Add a new non-time-varying data array.
 
         Parameters
         ----------
         name: `str`
-            Name of the measurement to add.
+            Name of the data array to add.
         data: `astropy.nddata.NDData`,
             The data to add.
         meta: `dict`, optional
-            The metadata associated with the measurement.
+            The metadata associated for the data array.
 
         Raises
         ------
@@ -474,12 +475,12 @@ class TimeData:
 
     def remove(self, measure_name: str):
         """
-        Remove an existing measurement (column).
+        Remove an existing measurement or support data array.
 
         Parameters
         ----------
         measure_name: `str`
-            Name of the measurement to remove.
+            Name of the variable to remove.
         """
         if measure_name in self._data.columns:
             self._data.remove_column(measure_name)
@@ -490,7 +491,7 @@ class TimeData:
 
     def plot(self, axes=None, columns=None, subplots=True, **plot_args):
         """
-        Plot the data.
+        Plot the measurement data.
 
         Parameters
         ----------

--- a/hermes_core/util/io.py
+++ b/hermes_core/util/io.py
@@ -130,6 +130,14 @@ class CDFHandler(TimeDataIOHandler):
             variable_keys = filter(lambda key: key != "Epoch", list(input_file.keys()))
             # Add Variable Attributtes from the CDF file to TimeSeries
             for var_name in variable_keys:
+                # Make sure the Variable is not multi-dimensional
+                if len(input_file[var_name].shape) > 1:
+                    warn_user(
+                        f"Measurement Variable {var_name} is multi-dimensional. Cannot add {var_name} to the TimeSeries"
+                    )
+                    # Skip to the next Variable
+                    continue
+
                 # Extract the Variable's Metadata
                 var_attrs = {}
                 for attr_name in input_file[var_name].attrs:

--- a/hermes_core/util/schema.py
+++ b/hermes_core/util/schema.py
@@ -17,6 +17,7 @@ from astropy import units as u
 import hermes_core
 from hermes_core import log
 from hermes_core.util import util, const
+from hermes_core.util.exceptions import warn_user
 
 __all__ = ["HERMESDataSchema"]
 
@@ -664,25 +665,59 @@ class HERMESDataSchema:
                 (guess_dims, guess_types, guess_elements) = self._types(
                     var_data.to_datetime()
                 )
-            else:
+            elif hasattr(var_data, "value"):
                 # Guess the const CDF Data Type
                 (guess_dims, guess_types, guess_elements) = self._types(var_data.value)
+            else:
+                # Guess the const CDF Data Type
+                (guess_dims, guess_types, guess_elements) = self._types(var_data.data)
 
         # Check the Attributes that can be derived
-        if not var_name == "time":
-            measurement_attributes["DEPEND_0"] = self._get_depend()
-        measurement_attributes["DISPLAY_TYPE"] = self._get_display_type()
-        measurement_attributes["FIELDNAM"] = self._get_fieldnam(var_name)
-        measurement_attributes["FILLVAL"] = self._get_fillval(guess_types[0])
-        measurement_attributes["FORMAT"] = self._get_format(var_data, guess_types[0])
-        measurement_attributes["LABLAXIS"] = self._get_lablaxis(data, var_name)
-        measurement_attributes["SI_CONVERSION"] = self._get_si_conversion(
-            data, var_name
-        )
-        measurement_attributes["UNITS"] = self._get_units(data, var_name)
-        measurement_attributes["VALIDMIN"] = self._get_validmin(guess_types[0])
-        measurement_attributes["VALIDMAX"] = self._get_validmax(guess_types[0])
-        measurement_attributes["VAR_TYPE"] = self._get_var_type()
+        var_type = self._get_var_type(data, var_name)
+
+        if var_type == "data":
+            if not var_name == "time":
+                measurement_attributes["DEPEND_0"] = self._get_depend()
+            measurement_attributes["DISPLAY_TYPE"] = self._get_display_type()
+            measurement_attributes["FIELDNAM"] = self._get_fieldnam(var_name)
+            measurement_attributes["FILLVAL"] = self._get_fillval(guess_types[0])
+            measurement_attributes["FORMAT"] = self._get_format(
+                var_data, guess_types[0]
+            )
+            measurement_attributes["LABLAXIS"] = self._get_lablaxis(data, var_name)
+            measurement_attributes["SI_CONVERSION"] = self._get_si_conversion(
+                data, var_name
+            )
+            measurement_attributes["UNITS"] = self._get_units(data, var_name)
+            measurement_attributes["VALIDMIN"] = self._get_validmin(guess_types[0])
+            measurement_attributes["VALIDMAX"] = self._get_validmax(guess_types[0])
+            measurement_attributes["VAR_TYPE"] = self._get_var_type(data, var_name)
+        elif var_type == "support_data":
+            measurement_attributes["FIELDNAM"] = self._get_fieldnam(var_name)
+            measurement_attributes["FILLVAL"] = self._get_fillval(guess_types[0])
+            measurement_attributes["FORMAT"] = self._get_format(
+                var_data, guess_types[0]
+            )
+            measurement_attributes["LABLAXIS"] = self._get_lablaxis(data, var_name)
+            measurement_attributes["SI_CONVERSION"] = self._get_si_conversion(
+                data, var_name
+            )
+            measurement_attributes["UNITS"] = self._get_units(data, var_name)
+            measurement_attributes["VALIDMIN"] = self._get_validmin(guess_types[0])
+            measurement_attributes["VALIDMAX"] = self._get_validmax(guess_types[0])
+            measurement_attributes["VAR_TYPE"] = self._get_var_type(data, var_name)
+        elif var_type == "metadata":
+            measurement_attributes["FIELDNAM"] = self._get_fieldnam(var_name)
+            measurement_attributes["FILLVAL"] = self._get_fillval(guess_types[0])
+            measurement_attributes["FORMAT"] = self._get_format(
+                var_data, guess_types[0]
+            )
+            measurement_attributes["VAR_TYPE"] = self._get_var_type(data, var_name)
+        else:
+            warn_user(
+                f"Variable {var_name} has unrecognizable VAR_TYPE ({var_type}). Cannot Derive Metadata for Variable."
+            )
+
         return measurement_attributes
 
     def derive_time_attributes(self, data):
@@ -932,6 +967,8 @@ class HERMESDataSchema:
             const.CDF_CHAR.value,
             const.CDF_UCHAR.value,
         ):
+            if hasattr(var_data, "data"):
+                var_data = var_data.data
             fmt = "A{}".format(len(var_data))
         else:
             raise ValueError(
@@ -973,8 +1010,15 @@ class HERMESDataSchema:
             conversion_rate = u.ns.to(u.s)
             si_conversion = f"{conversion_rate:e}>{u.s}"
         else:
-            conversion_rate = var_data.unit.to(var_data.si.unit)
-            si_conversion = f"{conversion_rate:e}>{var_data.si.unit}"
+            # Get the Units as a String
+            if isinstance(var_data, u.Quantity):
+                try:
+                    conversion_rate = var_data.unit.to(var_data.si.unit)
+                    si_conversion = f"{conversion_rate:e}>{var_data.si.unit}"
+                except u.UnitConversionError:
+                    si_conversion = f"1.0>{var_data.unit}"
+            else:
+                si_conversion = " > "
         return si_conversion
 
     def _get_time_base(self, guess_type):
@@ -1000,8 +1044,11 @@ class HERMESDataSchema:
         var_data = data[var_name]
         unit = ""
         # Get the Unit from the TimeSeries Quantity if it exists
-        if hasattr(var_data, "unit"):
+        if hasattr(var_data, "unit") and var_data.unit is not None:
             unit = var_data.unit.to_string()
+        # Try to ge the UNITS from the metadata
+        elif "UNITS" in var_data.meta and var_data.meta["UNITS"] is not None:
+            unit = var_data.meta["UNITS"]
         return unit
 
     def _get_validmin(self, guess_type):
@@ -1026,8 +1073,15 @@ class HERMESDataSchema:
             minval, maxval = self._get_minmax(guess_type)
             return maxval
 
-    def _get_var_type(self):
-        return "data"
+    def _get_var_type(self, data, var_name):
+        # Get the Variable Data
+        var_data = data[var_name]
+        attr_name = "VAR_TYPE"
+        if (attr_name not in var_data.meta) or (not var_data.meta[attr_name]):
+            var_type = "data"
+        else:
+            var_type = var_data.meta[attr_name]
+        return var_type
 
     # =============================================================================================
     #                             GLOBAL METADATA DERIVATIONS

--- a/hermes_core/util/tests/test_io.py
+++ b/hermes_core/util/tests/test_io.py
@@ -1,0 +1,102 @@
+"""Tests for Loading and Saving data from data containers"""
+
+from collections import OrderedDict
+from pathlib import Path
+import pytest
+import json
+import numpy as np
+from numpy.random import random
+import tempfile
+from astropy.timeseries import TimeSeries
+from astropy.time import Time
+from astropy.units import Quantity
+from spacepy.pycdf import CDFError, CDF
+from hermes_core.timedata import TimeData
+
+
+def get_test_timedata():
+    ts = TimeSeries()
+    ts.meta.update(
+        {
+            "Descriptor": "EEA>Electron Electrostatic Analyzer",
+            "Data_level": "l1>Level 1",
+            "Data_version": "v0.0.1",
+            "MODS": [
+                "v0.0.0 - Original version.",
+                "v1.0.0 - Include trajectory vectors and optics state.",
+                "v1.1.0 - Update metadata: counts -> flux.",
+                "v1.2.0 - Added flux error.",
+                "v1.3.0 - Trajectory vector errors are now deltas.",
+            ],
+        }
+    )
+
+    # Create an astropy.Time object
+    time = np.arange(10)
+    time_col = Time(time, format="unix")
+    ts["time"] = time_col
+
+    # Add Measurement
+    quant = Quantity(value=random(size=(10)), unit="m", dtype=np.uint16)
+    ts["measurement"] = quant
+    ts["measurement"].meta = OrderedDict(
+        {
+            "VAR_TYPE": "data",
+            "CATDESC": "Test Data",
+        }
+    )
+    timedata = TimeData(data=ts)
+    return timedata
+
+
+def test_cdf_io():
+    """Test CDF IO Handler on Default Data"""
+    # Get Test Datas
+    td = get_test_timedata()
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Convert TimeData the to a CDF File
+        test_file_output_path = td.save(output_path=tmpdirname)
+
+        # Load the CDF to a TimeData Object
+        td_loaded = TimeData.load(test_file_output_path)
+
+        assert td.shape == td_loaded.shape
+
+        with pytest.raises(CDFError):
+            td_loaded.save(output_path=tmpdirname)
+
+
+def test_cdf_bad_file_path():
+    """Test Loading CDF from a non-existant file"""
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Try loading from non-existant_path
+        with pytest.raises(FileNotFoundError):
+            _ = TimeData.load(tmpdirname + "non_existant_file.cdf")
+
+
+def test_cdf_nrv_support_data():
+    """
+    Test Loading Non-Record-Varying data with CDF IO Handler
+    """
+    # Get Test Datas
+    td = get_test_timedata()
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Convert TimeData the to a CDF File
+        test_file_output_path = td.save(output_path=tmpdirname)
+
+        # Load the JSON file as JSON
+        with CDF(test_file_output_path, readonly=False) as cdf_file:
+            # Add Non-Record-Varying Variable
+            cdf_file["Test_NRV_Var"] = [1, 2, 3]
+
+            # Add Support Data Variable
+            cdf_file["Test_Support_Var"] = np.arange(10)
+            cdf_file["Test_Support_Var"].meta["UNITS"] = "counts"
+
+        # Make sure we can load the modified JSON
+        td_loaded = TimeData.load(test_file_output_path)
+
+        assert "Test_NRV_Var" in td_loaded.nrv_data
+        assert "Test_Support_Var" in td_loaded.columns

--- a/hermes_core/util/tests/test_io.py
+++ b/hermes_core/util/tests/test_io.py
@@ -98,5 +98,5 @@ def test_cdf_nrv_support_data():
         # Make sure we can load the modified JSON
         td_loaded = TimeData.load(test_file_output_path)
 
-        assert "Test_NRV_Var" in td_loaded.nrv_data
+        assert "Test_NRV_Var" in td_loaded.support
         assert "Test_Support_Var" in td_loaded.columns

--- a/hermes_core/util/tests/test_schema.py
+++ b/hermes_core/util/tests/test_schema.py
@@ -387,7 +387,6 @@ def test_si_conversion():
     """Test the SI Units Conversion"""
     # Get Test TimeData
     test_data = get_test_timedata()
-    print()
     # Default in Test Data "m"
     assert (
         HERMESDataSchema()._get_si_conversion(test_data, "measurement")

--- a/hermes_core/util/tests/test_schema.py
+++ b/hermes_core/util/tests/test_schema.py
@@ -15,6 +15,41 @@ from hermes_core.util.schema import HERMESDataSchema
 from hermes_core.util import const
 
 
+def get_test_timedata():
+    ts = TimeSeries()
+    ts.meta.update(
+        {
+            "Descriptor": "EEA>Electron Electrostatic Analyzer",
+            "Data_level": "l1>Level 1",
+            "Data_version": "v0.0.1",
+            "MODS": [
+                "v0.0.0 - Original version.",
+                "v1.0.0 - Include trajectory vectors and optics state.",
+                "v1.1.0 - Update metadata: counts -> flux.",
+                "v1.2.0 - Added flux error.",
+                "v1.3.0 - Trajectory vector errors are now deltas.",
+            ],
+        }
+    )
+
+    # Create an astropy.Time object
+    time = np.arange(10)
+    time_col = Time(time, format="unix")
+    ts["time"] = time_col
+
+    # Add Measurement
+    quant = u.Quantity(value=random(size=(10)), unit="m", dtype=np.uint16)
+    ts["measurement"] = quant
+    ts["measurement"].meta = OrderedDict(
+        {
+            "VAR_TYPE": "data",
+            "CATDESC": "Test Data",
+        }
+    )
+    timedata = TimeData(data=ts)
+    return timedata
+
+
 def test_hermes_data_schema():
     """Test Schema Template and Info Functions"""
     schema = HERMESDataSchema()
@@ -346,6 +381,39 @@ def test_format():
         v = cdf.new("var", data=["hi", "there"])
         format = HERMESDataSchema()._get_format(cdf["var"], const.CDF_CHAR.value)
         assert "A2" == format
+
+
+def test_si_conversion():
+    """Test the SI Units Conversion"""
+    # Get Test TimeData
+    test_data = get_test_timedata()
+    print()
+    # Default in Test Data "m"
+    assert (
+        HERMESDataSchema()._get_si_conversion(test_data, "measurement")
+        == "1.000000e+00>m"
+    )
+
+    # Dimensionless Units
+    test_data.add_measurement(
+        measure_name="measurement1",
+        data=u.Quantity(
+            value=random(size=(10)), unit=u.dimensionless_unscaled, dtype=np.uint16
+        ),
+    )
+    assert HERMESDataSchema()._get_units(test_data, "measurement1") == ""
+    assert (
+        HERMESDataSchema()._get_si_conversion(test_data, "measurement1")
+        == "1.000000e+00>"
+    )
+
+    # Count as Units
+    test_data.add_measurement(
+        measure_name="measurement2",
+        data=u.Quantity(value=random(size=(10)), unit=u.ct, dtype=np.uint16),
+    )
+    assert HERMESDataSchema()._get_units(test_data, "measurement2") == "ct"
+    assert HERMESDataSchema()._get_si_conversion(test_data, "measurement2") == "1.0>ct"
 
 
 def test_resolution():


### PR DESCRIPTION
Adds:

- Support for loading time-varying support data that does not have recognized `astropy` units. Units will default to `u.dimensionless`
- `support` structure to TimeData that is a `dict`-of-`astropy.nddata.NDData` for non-time-varying data
- Isolates Schema attribute derivations for the `VAR_TYPE` of the given variable.
- Update Schema YAML files to reflect SPDF guidelines
- Fix Bug: #83

Closes #80, #83