### PR TITLE
Refactor and Rename HermesData

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ author = "HERMES SOC Team"
 
 # The full version, including alpha/beta/rc tags
 from hermes_core import __version__
-from hermes_core.util.schema import HERMESDataSchema
+from hermes_core.util.schema import HermesDataSchema
 
 version = __version__
 
@@ -50,15 +50,15 @@ extensions = [
 automodapi_toctreedirnm = "generated/api"
 
 # -- Generate CSV Files for Docs ---------------------------------------------
-if not os.path.exists('generated'):
-    os.mkdir('generated')  # generate the directory before putting things in it
+if not os.path.exists("generated"):
+    os.mkdir("generated")  # generate the directory before putting things in it
 # Global Attributes to CSV
 
-global_info = HERMESDataSchema.global_attribute_info()
+global_info = HermesDataSchema.global_attribute_info()
 global_info.write("./generated/global_attributes.csv", overwrite=True)
 
 # Variable Attributes to CSV
-variable_info = HERMESDataSchema.measurement_attribute_info()
+variable_info = HermesDataSchema.measurement_attribute_info()
 variable_info.write("./generated/variable_attributes.csv", overwrite=True)
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/examples/tutorial1.rst
+++ b/docs/examples/tutorial1.rst
@@ -60,7 +60,7 @@ measurement data easier when reading and writing CDF data.
     global_attrs_template["PI_name"] = "Dr. Eftyhia Zesta"
     global_attrs_template["TEXT"] = "Sample HERMES NEMISIS CDF File"
 
-    example_data = HermesData(data=ts, meta=global_attrs_template)
+    example_data = HermesData(timeseries=ts, meta=global_attrs_template)
 
     # To make the creation of variable metadata easier you can use the static
     # `HermesData.measurement_attribute_template()` function.

--- a/docs/examples/tutorial1.rst
+++ b/docs/examples/tutorial1.rst
@@ -1,7 +1,7 @@
 Creating a CDF File
 ===================
 
-This module provides an example for creating a CDF File using the `~hermes_core.timedata.TimeData`
+This module provides an example for creating a CDF File using the `~hermes_core.timedata.HermesData`
 class. This class is an abstraction of underlying data structures to make the handling of
 measurement data easier when reading and writing CDF data.
 
@@ -13,7 +13,7 @@ measurement data easier when reading and writing CDF data.
     from astropy.timeseries import TimeSeries
 
     # Import the `hermes_core` Package
-    from hermes_core.timedata import TimeData
+    from hermes_core.timedata import HermesData
     from hermes_core.util.validation import validate
 
     # Create a np.ndarray of example measurement data
@@ -32,8 +32,8 @@ measurement data easier when reading and writing CDF data.
         name="By GSE")
 
     # To make the creation of global metadata easier you can use the static
-    # `TimeData.global_attribute_template()` function.
-    global_attrs_template = TimeData.global_attribute_template()
+    # `HermesData.global_attribute_template()` function.
+    global_attrs_template = HermesData.global_attribute_template()
 
     global_attrs_template["DOI"] = "https://doi.org/<PREFIX>/<SUFFIX>"
     global_attrs_template["Data_level"] = "L1>Level 2"
@@ -60,21 +60,21 @@ measurement data easier when reading and writing CDF data.
     global_attrs_template["PI_name"] = "Dr. Eftyhia Zesta"
     global_attrs_template["TEXT"] = "Sample HERMES NEMISIS CDF File"
 
-    timedata = TimeData(data=ts, meta=global_attrs_template)
+    example_data = HermesData(data=ts, meta=global_attrs_template)
 
     # To make the creation of variable metadata easier you can use the static
-    # `TimeData.measurement_attribute_template()` function.
-    template = TimeData.measurement_attribute_template()
+    # `HermesData.measurement_attribute_template()` function.
+    template = HermesData.measurement_attribute_template()
 
     # Update the Metadata for each of the Measurements
-    timedata["Bx GSE"].meta.update(
+    example_data["Bx GSE"].meta.update(
         OrderedDict({"CATDESC": "X component of magnetic Field GSE"}))
-    timedata["By GSE"].meta.update(
+    example_data["By GSE"].meta.update(
         OrderedDict({"CATDESC": "Y component of magnetic Field GSE"}))
 
-    # You can also add new Measurements to the TimeData container
+    # You can also add new Measurements to the HermesData container
     bz = np.random.choice(a=[-1, 0, 1], size=1000).cumsum(0)
-    timedata.add_measurement(
+    example_data.add_measurement(
         measure_name="Bz GSE",
         data=u.Quantity(value=bz, unit="nanoTesla", dtype=np.int16),
         meta={
@@ -84,7 +84,7 @@ measurement data easier when reading and writing CDF data.
     )
 
     # create the CDF File
-    cdf_file_path = timedata.save(output_path="./", overwrite=True)
+    cdf_file_path = example_data.save(output_path="./", overwrite=True)
 
 The file that this code generates is made available as a sample file in this
 repository in :file:`hermes_core/data/sample/hermes_nms_default_l1_20160322_123031_v0.0.1.cdf`.

--- a/docs/user-guide/cdf_format_guide.rst
+++ b/docs/user-guide/cdf_format_guide.rst
@@ -483,6 +483,7 @@ convenience.
 * FIELDNAM
 * FILLVAL (if time varying)
 * FORMAT/FORM_PTR
+* LABLAXIS or LABL_PTR_i
 * SI_CONVERSION
 * UNITS/UNIT_PTR
 * VALIDMIN (if time varying)

--- a/docs/user-guide/cdf_format_guide.rst
+++ b/docs/user-guide/cdf_format_guide.rst
@@ -8,7 +8,7 @@ HERMES CDF Format Guide
 1. Introduction
 ===============
 
-The :py:class:`~hermes_core.util.schema.HERMESDataSchema` class provides an interface to
+The :py:class:`~hermes_core.util.schema.HermesDataSchema` class provides an interface to
 examine the HERMES CDF Format Guide.
 
 ---------------------
@@ -200,12 +200,12 @@ information is provided:
 * description: (`str`) A brief description of the attribute
 * default: (`str`) The default value used if none is provided
 * derived: (`bool`) Whether the attibute can be derived by the HERMES 
-  :py:class:`~hermes_core.util.schema.HERMESDataSchema` class
+  :py:class:`~hermes_core.util.schema.HermesDataSchema` class
 * required: (`bool`) Whether the attribute is required by HERMES standards
 * validate: (`bool`) Whether the attribute is included in the 
   :py:func:`~hermes_core.util.validation.validate` checks (Note, not all attributes that 
   are required are validated)
-* overwrite: (`bool`) Whether the :py:class:`~hermes_core.util.schema.HERMESDataSchema`
+* overwrite: (`bool`) Whether the :py:class:`~hermes_core.util.schema.HermesDataSchema`
   attribute derivations will overwrite an existing attribute value with an updated 
   attribute value from the derivation process.
 
@@ -529,9 +529,9 @@ information is provided:
 
 * description: (`str`) A brief description of the attribute
 * derived: (`bool`) Whether the attibute can be derived by the HERMES 
-  :py:class:`~hermes_core.util.schema.HERMESDataSchema` class
+  :py:class:`~hermes_core.util.schema.HermesDataSchema` class
 * required: (`bool`) Whether the attribute is required by HERMES standards
-* overwrite: (`bool`) Whether the :py:class:`~hermes_core.util.schema.HERMESDataSchema`
+* overwrite: (`bool`) Whether the :py:class:`~hermes_core.util.schema.HermesDataSchema`
   attribute derivations will overwrite an existing attribute value with an updated 
   attribute value from the derivation process.
 * valid_values: (`list`) List of allowed values the attribute can take for HERMES products,

--- a/docs/user-guide/reading_writing_data.rst
+++ b/docs/user-guide/reading_writing_data.rst
@@ -103,7 +103,7 @@ Here is an example with filled in values.
 You can now create the :py:class:`~hermes_core.timedata.HermesData` object,
 
     >>> from hermes_core.timedata import HermesData
-    >>> hermes_data = HermesData(data=ts, meta=input_attrs)
+    >>> hermes_data = HermesData(timeseries=ts, meta=input_attrs)
 
 The :py:class:`~hermes_core.timedata.HermesData` object also accepts optional arguments for loading
 non-record-varying (NRV) support data. These arguments are required to be a `dict`
@@ -111,7 +111,7 @@ of :py:class:`~astropy.nddata.NDData` objects.
 
     >>> from astropy.nddata import NDData
     >>> support = {"const_param": NDData(data=[1e-3])}
-    >>> hermes_data = HermesData(data=ts, meta=input_attrs, support=support)
+    >>> hermes_data = HermesData(timeseries=ts, meta=input_attrs, support=support)
 
 The :py:class:`~hermes_core.timedata.HermesData` is mutable so you can edit it, add another measurement column or edit the metadata after the fact.
 Your variable metadata can be found by querying the measurement column directly.
@@ -132,11 +132,11 @@ Putting it all together here is complete example
     ...    data={"Bx": u.Quantity([1, 2, 3, 4], "gauss", dtype=np.uint16)}
     ... )
     >>> input_attrs = HermesData.global_attribute_template("eea", "l1", "1.0.0")
-    >>> hermes_data = HermesData(data=ts, meta=input_attrs)
+    >>> hermes_data = HermesData(timeseries=ts, meta=input_attrs)
     >>> hermes_data['Bx'].meta.update({"CATDESC": "X component of the Magnetic field measured by HERMES"})
 
 Creating a ``HermesData`` from an existing CDF File
-=================================================
+===================================================
 
 Given a current CDF File you can load it into a :py:class:`~hermes_core.timedata.HermesData` by providing a path to the CDF file::
 
@@ -146,7 +146,7 @@ Given a current CDF File you can load it into a :py:class:`~hermes_core.timedata
 The :py:class:`~hermes_core.timedata.HermesData` can the be updated, measurements added, metadata added, and written to a new CDF file.
 
 Adding data to a ``HermesData`` Container
-=======================================
+=========================================
 
 A new column of data, support data, or NRV data can be added to an existing instance. Remember 
 that new data measurements must have the same time stamps as the existing ones and therefore 
@@ -342,7 +342,7 @@ By default, a plot will be generated with each measurement in its own plot panel
     >>> bz = np.concatenate([[0], np.random.choice(a=[-1, 0, 1], size=1000)]).cumsum(0)
     >>> ts = TimeSeries(time_start="2016-03-22T12:30:31", time_delta=3 * u.s, data={"Bx": u.Quantity(bx, "nanoTesla", dtype=np.int16)})
     >>> input_attrs = HermesData.global_attribute_template("nemisis", "l1", "1.0.0")
-    >>> hermes_data = HermesData(data=ts, meta=input_attrs)
+    >>> hermes_data = HermesData(timeseries=ts, meta=input_attrs)
     >>> hermes_data.add_measurement(measure_name=f"By", data=u.Quantity(by, 'nanoTesla', dtype=np.int16))
     >>> hermes_data.add_measurement(measure_name=f"Bz", data=u.Quantity(bz, 'nanoTesla', dtype=np.int16))
     >>> fig = plt.figure()

--- a/docs/user-guide/reading_writing_data.rst
+++ b/docs/user-guide/reading_writing_data.rst
@@ -105,6 +105,14 @@ You can now create the :py:class:`~hermes_core.timedata.TimeData` object,
     >>> from hermes_core.timedata import TimeData
     >>> timedata = TimeData(data=ts, meta=input_attrs)
 
+The :py:class:`~hermes_core.timedata.TimeData` object also accepts optional arguments for loading
+non-record-varying (NRV) support data. These arguments are required to be a `dict`
+of :py:class:`~astropy.nddata.NDData` objects.
+
+    >>> from astropy.nddata import NDData
+    >>> support = {"const_param": NDData(data=[1e-3])}
+    >>> timedata = TimeData(data=ts, meta=input_attrs, support=support)
+
 The :py:class:`~hermes_core.timedata.TimeData` is mutable so you can edit it, add another measurement column or edit the metadata after the fact.
 Your variable metadata can be found by querying the measurement column directly.
 
@@ -140,21 +148,31 @@ The :py:class:`~hermes_core.timedata.TimeData` can the be updated, measurements 
 Adding data to a ``TimeData`` Container
 =======================================
 
-A new column of data can be added to an existing instance.
-Remember that these new measurements must have the same time stamps as the existing ones and therefore the same number of measurements.
+A new column of data, support data, or NRV data can be added to an existing instance. Remember 
+that new data measurements must have the same time stamps as the existing ones and therefore 
+the same number of entries. Support data and non-record-varying data can be added as needed.
 You can add the new column in one of two ways.
+
 The more explicit approach is to use :py:func:`~hermes_core.timedata.TimeData.add_measurement` function::
 
     >>> data = u.Quantity(np.arange(len(timedata['Bx'])), 'Gauss', dtype=np.uint16)
     >>> timedata.add_measurement(measure_name="By", data=data, meta={"CATDESC": "Test Metadata"})
 
-Or you can just add the column directly.
+Or you can add the measurement data directly.
 
     >>> timedata["By"] = u.Quantity(np.arange(len(timedata['Bx'])), 'Gauss', dtype=np.uint16)
 
-Remember that you'll then have to fill in the meta data afterwards.
+Remember that you'll then have to fill in the variable's metadata attributes afterwards.
 
     >>> timedata['By'].meta.update(measure_meta) # doctest: +SKIP
+    
+To add non-time-varying support data use the :py:func:`~hermes_core.timedata.TimeData.add_support` function::
+
+    >>> timedata.add_support(
+    ...     name="Calibration_const",
+    ...     data=NDData(data=[1e-1]),
+    ...     meta={"CATDESC": "Calibration Factor", "VAR_TYPE": "metadata"},
+    ... )
 
 Adding metadata attributes
 ==========================

--- a/docs/user-guide/reading_writing_data.rst
+++ b/docs/user-guide/reading_writing_data.rst
@@ -204,7 +204,7 @@ lest this subset of global metadata attributes.
 Derived Global Attributes
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :py:class:`~hermes_core.util.schema.HERMESDataSchema` class derives several global metadata 
+The :py:class:`~hermes_core.util.schema.HermesDataSchema` class derives several global metadata 
 attributes required for ISTP compliance. The following global attribtues are derived:
 
 - `Data_type`
@@ -287,7 +287,7 @@ to be provided upon instantiation:
 Derived Variable Attributes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :py:class:`~hermes_core.util.schema.HERMESDataSchema` class derives several variable metadata
+The :py:class:`~hermes_core.util.schema.HermesDataSchema` class derives several variable metadata
 attributes required for ISTP compliance.
 
 -  `TIME_BASE`

--- a/docs/user-guide/reading_writing_data.rst
+++ b/docs/user-guide/reading_writing_data.rst
@@ -116,7 +116,7 @@ of :py:class:`~astropy.nddata.NDData` objects.
 The :py:class:`~hermes_core.timedata.HermesData` is mutable so you can edit it, add another measurement column or edit the metadata after the fact.
 Your variable metadata can be found by querying the measurement column directly.
 
-    >>> hermes_data['Bx'].meta # doctest: +SKIP
+    >>> hermes_data.timeseries['Bx'].meta # doctest: +SKIP
 
 The class does its best to fill in metadata fields if it can and leaves others blank that it cannot.
 Those should be filled in manually.
@@ -133,7 +133,7 @@ Putting it all together here is complete example
     ... )
     >>> input_attrs = HermesData.global_attribute_template("eea", "l1", "1.0.0")
     >>> hermes_data = HermesData(timeseries=ts, meta=input_attrs)
-    >>> hermes_data['Bx'].meta.update({"CATDESC": "X component of the Magnetic field measured by HERMES"})
+    >>> hermes_data.timeseries['Bx'].meta.update({"CATDESC": "X component of the Magnetic field measured by HERMES"})
 
 Creating a ``HermesData`` from an existing CDF File
 ===================================================
@@ -151,20 +151,10 @@ Adding data to a ``HermesData`` Container
 A new column of data, support data, or NRV data can be added to an existing instance. Remember 
 that new data measurements must have the same time stamps as the existing ones and therefore 
 the same number of entries. Support data and non-record-varying data can be added as needed.
-You can add the new column in one of two ways.
+You can add the new column by using the :py:func:`~hermes_core.timedata.HermesData.add_measurement` function::
 
-The more explicit approach is to use :py:func:`~hermes_core.timedata.HermesData.add_measurement` function::
-
-    >>> data = u.Quantity(np.arange(len(hermes_data['Bx'])), 'Gauss', dtype=np.uint16)
+    >>> data = u.Quantity(np.arange(len(hermes_data.timeseries['Bx'])), 'Gauss', dtype=np.uint16)
     >>> hermes_data.add_measurement(measure_name="By", data=data, meta={"CATDESC": "Test Metadata"})
-
-Or you can add the measurement data directly.
-
-    >>> hermes_data["By"] = u.Quantity(np.arange(len(hermes_data['Bx'])), 'Gauss', dtype=np.uint16)
-
-Remember that you'll then have to fill in the variable's metadata attributes afterwards.
-
-    >>> hermes_data['By'].meta.update(measure_meta) # doctest: +SKIP
     
 To add non-time-varying support data use the :py:func:`~hermes_core.timedata.HermesData.add_support` function::
 

--- a/docs/user-guide/reading_writing_data.rst
+++ b/docs/user-guide/reading_writing_data.rst
@@ -7,7 +7,7 @@ Opening and Writing HERMES Data
 Overview
 ========
 
-The :py:class:`~hermes_core.timedata.TimeData` class provides a convenient and efficient way to work with HERMES science CDF data files.
+The :py:class:`~hermes_core.timedata.HermesData` class provides a convenient and efficient way to work with HERMES science CDF data files.
 The point of this class is to simplify data management, enhances data discovery, and facilitates adherence to CDF standards.
 
 `CDF (Common Data Format) <https://cdf.gsfc.nasa.gov>`_ files are a binary file format commonly used by NASA scientific research to store and exchange data. They provide a flexible structure for organizing and representing multidimensional datasets along with associated metadata. CDF files are widely used in space physics. Because of their versatility, CDF files can be complex.
@@ -23,18 +23,18 @@ CDF libraries in your local environment. Alternatively, the CDF library is insta
 through the HERMES development Docker continer environment. For more information on the HERMES Docker
 container please see our :doc:`Development Environment Page </dev-guide/dev_env>`.
 
-To make it easier to work with HERMES data, the :py:class:`~hermes_core.timedata.TimeData` class facilitates the abstraction of HERMES CDF files.
+To make it easier to work with HERMES data, the :py:class:`~hermes_core.timedata.HermesData` class facilitates the abstraction of HERMES CDF files.
 It allows users to read and write HERMES data and is compliant with `PyHC expectations <https://heliopython.org>`_.
 The data is stored in a `~astropy.timeseries.TimeSeries` table while the metadata is stored in dictionaries.
 `~astropy.timeseries.TimeSeries` is a Python class for handling scientific time series data that provides a convenient and familiar interface for working with tabular data.
 By loading the contents of a CDF file into a `~astropy.timeseries.TimeSeries` table, it becomes easier to manipulate, analyze, and visualize the data.
 Additionally, metadata attributes can be associated with the table, allowing for enhanced documentation and data discovery.
-The :py:class:`~hermes_core.timedata.TimeData` class aims to provide a simplified interface to reading and writing HERMES data and metadata to CDF files while automatically handling the complexities of the underlying CDF file format.
+The :py:class:`~hermes_core.timedata.HermesData` class aims to provide a simplified interface to reading and writing HERMES data and metadata to CDF files while automatically handling the complexities of the underlying CDF file format.
 
-Creating a ``TimeData`` object
+Creating a ``HermesData`` object
 ==============================
 
-A :py:class:`~hermes_core.timedata.TimeData` must be initialized by providing a `~astropy.timeseries.TimeSeries` object with at least one measurement.
+A :py:class:`~hermes_core.timedata.HermesData` must be initialized by providing a `~astropy.timeseries.TimeSeries` object with at least one measurement.
 There are many ways to initialize one but here is one example:
 
     >>> import numpy as np
@@ -59,10 +59,10 @@ You can also create your time array directly
     ...        data={'diff_e_flux': u.Quantity(np.arange(100) * 1e-3, '1/(cm**2 * s * eV * steradian)', dtype=np.float32)}
     ...    )
 
-Note the use of `~astropy.time` and `astropy.units` which provide several advantages over using arrays of numbers and are required by :py:class:`~hermes_core.timedata.TimeData`.
+Note the use of `~astropy.time` and `astropy.units` which provide several advantages over using arrays of numbers and are required by :py:class:`~hermes_core.timedata.HermesData`.
 
 Next create a `dict` or `~collections.OrderedDict` containing the required CDF global metadata.
-The class function :py:func:`~hermes_core.timedata.TimeData.global_attribute_template`:: will provide you an empty version that you can fill in if needed.
+The class function :py:func:`~hermes_core.timedata.HermesData.global_attribute_template`:: will provide you an empty version that you can fill in if needed.
 Here is an example with filled in values.
 
     >>> input_attrs = {
@@ -100,23 +100,23 @@ Here is an example with filled in values.
     ...     "TEXT": "Valid Test Case",
     ... }
 
-You can now create the :py:class:`~hermes_core.timedata.TimeData` object,
+You can now create the :py:class:`~hermes_core.timedata.HermesData` object,
 
-    >>> from hermes_core.timedata import TimeData
-    >>> timedata = TimeData(data=ts, meta=input_attrs)
+    >>> from hermes_core.timedata import HermesData
+    >>> hermes_data = HermesData(data=ts, meta=input_attrs)
 
-The :py:class:`~hermes_core.timedata.TimeData` object also accepts optional arguments for loading
+The :py:class:`~hermes_core.timedata.HermesData` object also accepts optional arguments for loading
 non-record-varying (NRV) support data. These arguments are required to be a `dict`
 of :py:class:`~astropy.nddata.NDData` objects.
 
     >>> from astropy.nddata import NDData
     >>> support = {"const_param": NDData(data=[1e-3])}
-    >>> timedata = TimeData(data=ts, meta=input_attrs, support=support)
+    >>> hermes_data = HermesData(data=ts, meta=input_attrs, support=support)
 
-The :py:class:`~hermes_core.timedata.TimeData` is mutable so you can edit it, add another measurement column or edit the metadata after the fact.
+The :py:class:`~hermes_core.timedata.HermesData` is mutable so you can edit it, add another measurement column or edit the metadata after the fact.
 Your variable metadata can be found by querying the measurement column directly.
 
-    >>> timedata['Bx'].meta # doctest: +SKIP
+    >>> hermes_data['Bx'].meta # doctest: +SKIP
 
 The class does its best to fill in metadata fields if it can and leaves others blank that it cannot.
 Those should be filled in manually.
@@ -124,28 +124,28 @@ Be careful when editing metadata that was automatically generated as you might m
 
 Putting it all together here is complete example
 
-    >>> from hermes_core.timedata import TimeData
+    >>> from hermes_core.timedata import HermesData
     >>> import astropy.units as u
     >>> ts = TimeSeries(
     ...    time_start="2016-03-22T12:30:31",
     ...    time_delta=3 * u.s,
     ...    data={"Bx": u.Quantity([1, 2, 3, 4], "gauss", dtype=np.uint16)}
     ... )
-    >>> input_attrs = TimeData.global_attribute_template("eea", "l1", "1.0.0")
-    >>> timedata = TimeData(data=ts, meta=input_attrs)
-    >>> timedata['Bx'].meta.update({"CATDESC": "X component of the Magnetic field measured by HERMES"})
+    >>> input_attrs = HermesData.global_attribute_template("eea", "l1", "1.0.0")
+    >>> hermes_data = HermesData(data=ts, meta=input_attrs)
+    >>> hermes_data['Bx'].meta.update({"CATDESC": "X component of the Magnetic field measured by HERMES"})
 
-Creating a ``TimeData`` from an existing CDF File
+Creating a ``HermesData`` from an existing CDF File
 =================================================
 
-Given a current CDF File you can load it into a :py:class:`~hermes_core.timedata.TimeData` by providing a path to the CDF file::
+Given a current CDF File you can load it into a :py:class:`~hermes_core.timedata.HermesData` by providing a path to the CDF file::
 
-    >>> from hermes_core.timedata import TimeData
-    >>> timedata = TimeData.load("hermes_eea_default_ql_19700101_v0.0.1.cdf") # doctest: +SKIP
+    >>> from hermes_core.timedata import HermesData
+    >>> hermes_data = HermesData.load("hermes_eea_default_ql_19700101_v0.0.1.cdf") # doctest: +SKIP
 
-The :py:class:`~hermes_core.timedata.TimeData` can the be updated, measurements added, metadata added, and written to a new CDF file.
+The :py:class:`~hermes_core.timedata.HermesData` can the be updated, measurements added, metadata added, and written to a new CDF file.
 
-Adding data to a ``TimeData`` Container
+Adding data to a ``HermesData`` Container
 =======================================
 
 A new column of data, support data, or NRV data can be added to an existing instance. Remember 
@@ -153,22 +153,22 @@ that new data measurements must have the same time stamps as the existing ones a
 the same number of entries. Support data and non-record-varying data can be added as needed.
 You can add the new column in one of two ways.
 
-The more explicit approach is to use :py:func:`~hermes_core.timedata.TimeData.add_measurement` function::
+The more explicit approach is to use :py:func:`~hermes_core.timedata.HermesData.add_measurement` function::
 
-    >>> data = u.Quantity(np.arange(len(timedata['Bx'])), 'Gauss', dtype=np.uint16)
-    >>> timedata.add_measurement(measure_name="By", data=data, meta={"CATDESC": "Test Metadata"})
+    >>> data = u.Quantity(np.arange(len(hermes_data['Bx'])), 'Gauss', dtype=np.uint16)
+    >>> hermes_data.add_measurement(measure_name="By", data=data, meta={"CATDESC": "Test Metadata"})
 
 Or you can add the measurement data directly.
 
-    >>> timedata["By"] = u.Quantity(np.arange(len(timedata['Bx'])), 'Gauss', dtype=np.uint16)
+    >>> hermes_data["By"] = u.Quantity(np.arange(len(hermes_data['Bx'])), 'Gauss', dtype=np.uint16)
 
 Remember that you'll then have to fill in the variable's metadata attributes afterwards.
 
-    >>> timedata['By'].meta.update(measure_meta) # doctest: +SKIP
+    >>> hermes_data['By'].meta.update(measure_meta) # doctest: +SKIP
     
-To add non-time-varying support data use the :py:func:`~hermes_core.timedata.TimeData.add_support` function::
+To add non-time-varying support data use the :py:func:`~hermes_core.timedata.HermesData.add_support` function::
 
-    >>> timedata.add_support(
+    >>> hermes_data.add_support(
     ...     name="Calibration_const",
     ...     data=NDData(data=[1e-1]),
     ...     meta={"CATDESC": "Calibration Factor", "VAR_TYPE": "metadata"},
@@ -178,27 +178,27 @@ Adding metadata attributes
 ==========================
 
 Additional CDF file global metadata and variable metadata can be easily added to a 
-:py:class:`~hermes_core.timedata.TimeData` data container. For more information about the required 
+:py:class:`~hermes_core.timedata.HermesData` data container. For more information about the required 
 metadata attributes please see the :doc:`HERMES CDF Format Guide </user-guide/cdf_format_guide>`
 
 Global Metadata Attributes
 --------------------------
 
-Global metadata attributes can be updated for a :py:class:`~hermes_core.timedata.TimeData` object 
-using the object's :py:attr:`~hermes_core.timedata.TimeData.meta` parameter which is an 
+Global metadata attributes can be updated for a :py:class:`~hermes_core.timedata.HermesData` object 
+using the object's :py:attr:`~hermes_core.timedata.HermesData.meta` parameter which is an 
 `~collections.OrderedDict` containing all attributes. 
 
 Required Global Attributes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :py:class:`~hermes_core.timedata.TimeData` class requires several global metadata attributes 
+The :py:class:`~hermes_core.timedata.HermesData` class requires several global metadata attributes 
 to be provided upon instantiation:
 
 - `Descriptor`
 - `Data_level`
 - `Data_version`
 
-A :py:class:`~hermes_core.timedata.TimeData` container cannot be created without supplying at 
+A :py:class:`~hermes_core.timedata.HermesData` container cannot be created without supplying at 
 lest this subset of global metadata attributes. 
 
 Derived Global Attributes
@@ -221,11 +221,11 @@ Using a Template for Global Metadata Attributes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A template of the required metadata can be obtained using the 
-:py:func:`~hermes_core.timedata.TimeData.global_attribute_template` function::
+:py:func:`~hermes_core.timedata.HermesData.global_attribute_template` function::
 
     >>> from collections import OrderedDict
-    >>> from hermes_core.timedata import TimeData
-    >>> TimeData.global_attribute_template()
+    >>> from hermes_core.timedata import HermesData
+    >>> HermesData.global_attribute_template()
     OrderedDict([('DOI', None),
              ('Data_level', None),
              ('Data_version', None),
@@ -244,8 +244,8 @@ A template of the required metadata can be obtained using the
 You can also pass arguments into the function to get a partially populated template:: 
 
     >>> from collections import OrderedDict
-    >>> from hermes_core.timedata import TimeData
-    >>> TimeData.global_attribute_template(
+    >>> from hermes_core.timedata import HermesData
+    >>> HermesData.global_attribute_template(
     ...     instr_name='eea', 
     ...     data_level='l1',
     ...     version='0.1.0'
@@ -267,19 +267,19 @@ You can also pass arguments into the function to get a partially populated templ
 This can make the definition of global metadata easier since instrument teams or users only need 
 to supply pieces of metadata that are in this template. Additional metadata items can be added 
 if desired. Once the template is instantiated and all attributes have been filled out, you can
-use this  duruing instantiation of your :py:class:`~hermes_core.timedata.TimeData` container.
+use this  duruing instantiation of your :py:class:`~hermes_core.timedata.HermesData` container.
 
 Variable Metadata Attributes
 ----------------------------
 
-Variable metadata requirements can be updated for a :py:class:`~hermes_core.timedata.TimeData` 
-variable using the variable's :py:attr:`~hermes_core.timedata.TimeData.meta` property which is an 
+Variable metadata requirements can be updated for a :py:class:`~hermes_core.timedata.HermesData` 
+variable using the variable's :py:attr:`~hermes_core.timedata.HermesData.meta` property which is an 
 `~collections.OrderedDict` of all attributes. 
 
 Required Variable Attributes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :py:class:`~hermes_core.timedata.TimeData` class requires one variable metadata attribute
+The :py:class:`~hermes_core.timedata.HermesData` class requires one variable metadata attribute
 to be provided upon instantiation:
 
 - `CATDESC` : (Catalogue Description) This is a human readable description of the data variable.
@@ -313,20 +313,20 @@ Using a Template for Variable Metadata Attributes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A template of the required metadata can be obtained using the 
-:py:func:`~hermes_core.timedata.TimeData.measurement_attribute_template` function::
+:py:func:`~hermes_core.timedata.HermesData.measurement_attribute_template` function::
 
     >>> from collections import OrderedDict
-    >>> from hermes_core.timedata import TimeData
-    >>> TimeData.measurement_attribute_template()
+    >>> from hermes_core.timedata import HermesData
+    >>> HermesData.measurement_attribute_template()
     OrderedDict([('CATDESC', None)])
 
-If you use the :py:func:`~hermes_core.timedata.TimeData.add_measurement` function, it will 
+If you use the :py:func:`~hermes_core.timedata.HermesData.add_measurement` function, it will 
 automatically fill most of them in for you. Additional pieces of metadata can be added if desired.
 
-Visualizing data in a ``TimeData`` Container
+Visualizing data in a ``HermesData`` Container
 ============================================
 
-The :py:class:`~hermes_core.timedata.TimeData` provides a quick way to visualize its data through `~hermes_core.timedata.TimeData.plot`.
+The :py:class:`~hermes_core.timedata.HermesData` provides a quick way to visualize its data through `~hermes_core.timedata.HermesData.plot`.
 By default, a plot will be generated with each measurement in its own plot panel.
 
 .. plot::
@@ -336,24 +336,24 @@ By default, a plot will be generated with each measurement in its own plot panel
     >>> import matplotlib.pyplot as plt
     >>> import astropy.units as u
     >>> from astropy.timeseries import TimeSeries
-    >>> from hermes_core.timedata import TimeData
+    >>> from hermes_core.timedata import HermesData
     >>> bx = np.concatenate([[0], np.random.choice(a=[-1, 0, 1], size=1000)]).cumsum(0)
     >>> by = np.concatenate([[0], np.random.choice(a=[-1, 0, 1], size=1000)]).cumsum(0)
     >>> bz = np.concatenate([[0], np.random.choice(a=[-1, 0, 1], size=1000)]).cumsum(0)
     >>> ts = TimeSeries(time_start="2016-03-22T12:30:31", time_delta=3 * u.s, data={"Bx": u.Quantity(bx, "nanoTesla", dtype=np.int16)})
-    >>> input_attrs = TimeData.global_attribute_template("nemisis", "l1", "1.0.0")
-    >>> timedata = TimeData(data=ts, meta=input_attrs)
-    >>> timedata.add_measurement(measure_name=f"By", data=u.Quantity(by, 'nanoTesla', dtype=np.int16))
-    >>> timedata.add_measurement(measure_name=f"Bz", data=u.Quantity(bz, 'nanoTesla', dtype=np.int16))
+    >>> input_attrs = HermesData.global_attribute_template("nemisis", "l1", "1.0.0")
+    >>> hermes_data = HermesData(data=ts, meta=input_attrs)
+    >>> hermes_data.add_measurement(measure_name=f"By", data=u.Quantity(by, 'nanoTesla', dtype=np.int16))
+    >>> hermes_data.add_measurement(measure_name=f"Bz", data=u.Quantity(bz, 'nanoTesla', dtype=np.int16))
     >>> fig = plt.figure()
-    >>> timedata.plot() # doctest: +SKIP
+    >>> hermes_data.plot() # doctest: +SKIP
     >>> plt.show() # doctest: +SKIP
 
 Writing a CDF File
 ==================
 
-The :py:class:`~hermes_core.timedata.TimeData` class writes CDF files using the `~spacepy.pycdf` module.
-This can be done using the :py:func:`~hermes_core.timedata.TimeData.save` method which only requires a path to the folder where the CDF file should be saved.
+The :py:class:`~hermes_core.timedata.HermesData` class writes CDF files using the `~spacepy.pycdf` module.
+This can be done using the :py:func:`~hermes_core.timedata.HermesData.save` method which only requires a path to the folder where the CDF file should be saved.
 The filename is automatically derived consistent with HERMES filenaming requirements.
 If no path is provided it writes the file to the current directory.
 This function returns the full path to the CDF file that was generated.
@@ -362,7 +362,7 @@ From this you can validate and distribute your CDF file.
 Validating a CDF File
 =====================
 
-The :py:class:`~hermes_core.timedata.TimeData` uses the `~spacepy.pycdf.istp` module for CDF validation, in addition to custom
+The :py:class:`~hermes_core.timedata.HermesData` uses the `~spacepy.pycdf.istp` module for CDF validation, in addition to custom
 tests for additional metadata. A CDF file can be validated using the :py:func:`~hermes_core.util.validation.validate` method
 and by passing, as a parameter, the full path to the CDF file to be validated::
 

--- a/docs/user-guide/reading_writing_data.rst
+++ b/docs/user-guide/reading_writing_data.rst
@@ -32,7 +32,7 @@ Additionally, metadata attributes can be associated with the table, allowing for
 The :py:class:`~hermes_core.timedata.HermesData` class aims to provide a simplified interface to reading and writing HERMES data and metadata to CDF files while automatically handling the complexities of the underlying CDF file format.
 
 Creating a ``HermesData`` object
-==============================
+================================
 
 A :py:class:`~hermes_core.timedata.HermesData` must be initialized by providing a `~astropy.timeseries.TimeSeries` object with at least one measurement.
 There are many ways to initialize one but here is one example:
@@ -317,7 +317,7 @@ If you use the :py:func:`~hermes_core.timedata.HermesData.add_measurement` funct
 automatically fill most of them in for you. Additional pieces of metadata can be added if desired.
 
 Visualizing data in a ``HermesData`` Container
-============================================
+==============================================
 
 The :py:class:`~hermes_core.timedata.HermesData` provides a quick way to visualize its data through `~hermes_core.timedata.HermesData.plot`.
 By default, a plot will be generated with each measurement in its own plot panel.

--- a/hermes_core/data/hermes_default_variable_cdf_attrs_schema.yaml
+++ b/hermes_core/data/hermes_default_variable_cdf_attrs_schema.yaml
@@ -362,6 +362,7 @@ support_data:
   - FIELDNAM
   - FILLVAL
   - FORMAT
+  - LABLAXIS
   - SI_CONVERSION
   - UNITS
   - VALIDMIN
@@ -370,5 +371,6 @@ support_data:
 metadata:
   - CATDESC
   - FIELDNAM
+  - FILLVAL
   - FORMAT
   - VAR_TYPE

--- a/hermes_core/tests/test_timedata.py
+++ b/hermes_core/tests/test_timedata.py
@@ -204,6 +204,9 @@ def test_default_properties():
     # time_range
     assert isinstance(test_data.time_range, tuple)
 
+    # __repr__
+    assert isinstance(test_data.__repr__(), str)
+
 
 def test_hermes_data_single_measurement():
     # fmt: off

--- a/hermes_core/tests/test_timedata.py
+++ b/hermes_core/tests/test_timedata.py
@@ -30,7 +30,9 @@ def get_bad_timeseries():
     ts.add_column(col)
 
     # Add Measurement
-    col = Column(data=random(size=(10)), name="measurement", meta={"CATDESC": "Test Measurement"})
+    col = Column(
+        data=random(size=(10)), name="measurement", meta={"CATDESC": "Test Measurement"}
+    )
     ts.add_column(col)
     return ts
 
@@ -688,7 +690,9 @@ def test_hermes_data_idempotency():
         for var in test_data.timeseries.columns:
             assert var in loaded_data.timeseries.columns
             assert len(test_data.timeseries[var]) == len(loaded_data.timeseries[var])
-            assert len(test_data.timeseries[var].meta) == len(loaded_data.timeseries[var].meta)
+            assert len(test_data.timeseries[var].meta) == len(
+                loaded_data.timeseries[var].meta
+            )
             assert (
                 test_data.timeseries[var].meta["VAR_TYPE"]
                 == loaded_data.timeseries[var].meta["VAR_TYPE"]
@@ -696,10 +700,15 @@ def test_hermes_data_idempotency():
 
         for var in test_data.support:
             assert var in loaded_data.support
-            assert test_data.support[var].data.shape == loaded_data.support[var].data.shape
-            assert len(test_data.support[var].meta) == len(loaded_data.support[var].meta)
             assert (
-                test_data.support[var].meta["VAR_TYPE"] == loaded_data.support[var].meta["VAR_TYPE"]
+                test_data.support[var].data.shape == loaded_data.support[var].data.shape
+            )
+            assert len(test_data.support[var].meta) == len(
+                loaded_data.support[var].meta
+            )
+            assert (
+                test_data.support[var].meta["VAR_TYPE"]
+                == loaded_data.support[var].meta["VAR_TYPE"]
             )
 
 

--- a/hermes_core/tests/test_timedata.py
+++ b/hermes_core/tests/test_timedata.py
@@ -198,6 +198,19 @@ def test_default_properties():
     # data
     assert isinstance(test_data.timeseries, TimeSeries)
 
+    # support
+    assert isinstance(test_data.support, dict)
+
+    # data
+    assert isinstance(test_data.data, dict)
+    assert "timeseries" in test_data.data
+    assert isinstance(test_data.data["timeseries"], TimeSeries)
+    assert "support" in test_data.data
+    assert isinstance(test_data.data["support"], dict)
+
+    # meta
+    assert isinstance(test_data.meta, dict)
+
     # time
     assert isinstance(test_data.time, Time)
 

--- a/hermes_core/tests/test_timedata.py
+++ b/hermes_core/tests/test_timedata.py
@@ -64,7 +64,7 @@ def get_test_hermes_data():
         data={"Bx": Quantity([1, 2, 3, 4], "gauss", dtype=np.uint16)},
     )
     input_attrs = HermesData.global_attribute_template("eea", "l1", "1.0.0")
-    hermes_data = HermesData(data=ts, meta=input_attrs)
+    hermes_data = HermesData(timeseries=ts, meta=input_attrs)
     hermes_data["Bx"].meta.update({"CATDESC": "Test"})
     return hermes_data
 
@@ -75,18 +75,18 @@ def get_test_global_meta():
 
 def test_non_timeseries():
     with pytest.raises(TypeError):
-        _ = HermesData(data=[], meta={})
+        _ = HermesData(timeseries=[], meta={})
 
 
 def test_hermes_data_empty_ts():
     with pytest.raises(ValueError):
-        _ = HermesData(data=TimeSeries())
+        _ = HermesData(timeseries=TimeSeries())
 
 
 def test_hermes_data_bad_ts():
     ts = get_bad_timeseries()
     with pytest.raises(TypeError):
-        _ = HermesData(data=ts)
+        _ = HermesData(timeseries=ts)
 
 
 def test_hermes_data_default():
@@ -196,7 +196,7 @@ def test_default_properties():
     test_data = HermesData(ts, meta=input_attrs)
 
     # data
-    assert isinstance(test_data.data, TimeSeries)
+    assert isinstance(test_data.timeseries, TimeSeries)
 
     # units
     assert isinstance(test_data.units, OrderedDict)
@@ -788,7 +788,7 @@ def test_bitlength_save_cdf(bitlength):
     }
     # fmt: on
 
-    hermes_data = HermesData(data=ts, meta=input_attrs)
+    hermes_data = HermesData(timeseries=ts, meta=input_attrs)
     hermes_data["Bx"].meta.update({"CATDESC": "Test"})
     with tempfile.TemporaryDirectory() as tmpdirname:
         test_file_output_path = hermes_data.save(output_path=tmpdirname)

--- a/hermes_core/tests/test_timedata.py
+++ b/hermes_core/tests/test_timedata.py
@@ -12,7 +12,8 @@ from astropy.table import Column
 from astropy.time import Time
 from astropy.units import Quantity
 import astropy.units as u
-from spacepy.pycdf import CDFError
+from astropy.nddata import NDData
+from spacepy.pycdf import CDF, CDFError
 from matplotlib.axes import Axes
 import hermes_core
 from hermes_core.timedata import TimeData
@@ -49,8 +50,8 @@ def get_test_timeseries():
     ts["measurement"] = quant
     ts["measurement"].meta = OrderedDict(
         {
-            "VAR_TYPE": "metadata",
-            "CATDESC": "Test Metadata",
+            "VAR_TYPE": "data",
+            "CATDESC": "Test Data",
         }
     )
     return ts
@@ -109,6 +110,31 @@ def test_multidimensional_data():
         _ = TimeData(ts)
 
 
+def test_support_data():
+    # fmt: off
+    input_attrs = {
+        "Descriptor": "EEA>Electron Electrostatic Analyzer",
+        "Data_level": "l1>Level 1",
+        "Data_version": "v0.0.1",
+    }
+    # fmt: on
+    ts = get_test_timeseries()
+
+    # Bad Support
+    support = {"support_var": [1]}
+    with pytest.raises(TypeError):
+        _ = TimeData(ts, support=support, meta=input_attrs)
+
+    # Good Support
+    support = {"support_var": NDData(data=[1])}
+
+    # Create TimeData
+    test_data = TimeData(ts, support=support, meta=input_attrs)
+
+    assert "support_var" in test_data.support
+    assert test_data.support["support_var"].data[0] == 1
+
+
 def test_timedata_valid_attrs():
     # fmt: off
     input_attrs = {
@@ -148,10 +174,10 @@ def test_global_attribute_template():
 
     # good inputs
     template = TimeData.global_attribute_template(
-        instr_name="eea", data_level="l2", version="1.3.6"
+        instr_name="eea", data_level="ql", version="1.3.6"
     )
     assert template["Descriptor"] == "EEA>Electron Electrostatic Analyzer"
-    assert template["Data_level"] == "L2>Level 2"
+    assert template["Data_level"] == "QL>Quicklook"
     assert template["Data_version"] == "1.3.6"
 
 
@@ -254,11 +280,66 @@ def test_timedata_add_measurement():
     q = Quantity(value=random(size=(10)), unit="s", dtype=np.uint16)
     q.meta = OrderedDict({"CATDESC": "Test Variable"})
     test_data.add_measurement(measure_name="test", data=q)
-    assert len(test_data) == 1 + data_len
+    assert test_data["test"].shape == (10,)
+
+    # Add Dimensionless Record-Varying Data
+    q = Quantity(value=random(size=(10)), unit=u.dimensionless_unscaled)
+    test_data.add_measurement(
+        measure_name="Test Dimensionless",
+        data=q,
+        meta={"CATDESC": "Test Dimensionless Data", "VAR_TYPE": "support_data"},
+    )
+    assert test_data["Test Dimensionless"].shape == (10,)
+
+    # Add Count-Based Record-Varying Data
+    q = Quantity(value=random(size=(10)), unit=u.count)
+    test_data.add_measurement(
+        measure_name="Test Count",
+        data=q,
+        meta={"CATDESC": "Test Count Data", "VAR_TYPE": "support_data"},
+    )
+    assert test_data["Test Count"].shape == (10,)
 
     # test remove_measurement
-    test_data.remove_measurement("test")
-    assert len(test_data) == data_len
+    test_data.remove("test")
+    assert "test" not in test_data
+
+    # Test non-existent variable
+    with pytest.raises(ValueError):
+        test_data.remove("bad_variable")
+
+
+def test_timedata_add_support():
+    """Function to Test Adding Support/ Non-Record-Varying Data"""
+    # fmt: off
+    input_attrs = {
+        "Descriptor": "EEA>Electron Electrostatic Analyzer",
+        "Data_level": "l1>Level 1",
+        "Data_version": "v0.0.1",
+    }
+    # fmt: on
+
+    ts = get_test_timeseries()
+    # Initialize a CDF File Wrapper
+    test_data = TimeData(ts, meta=input_attrs)
+
+    # Add non-Quantity
+    with pytest.raises(TypeError):
+        test_data.add_support(name="test", data=[], meta={})
+
+    # Add Test Metadata
+    c = NDData(data=[1])
+    test_data.add_support(
+        name="Test Metadata",
+        data=c,
+        meta={"CATDESC": "Test Metadata Variable", "VAR_TYPE": "metadata"},
+    )
+    assert "Test Metadata" in test_data.support
+    assert test_data.support["Test Metadata"].data[0] == 1
+
+    # Test remove Support Data
+    test_data.remove("Test Metadata")
+    assert "Test Metadata" not in test_data
 
 
 def test_timedata_plot():
@@ -374,8 +455,14 @@ def test_timedata_generate_valid_cdf():
     # fmt: on
 
     ts = get_test_timeseries()
+    support = {
+        "nrv_var": NDData(
+            data=[1, 2, 3],
+            meta={"CATDESC": "Test Metadata Variable", "VAR_TYPE": "metadata"},
+        )
+    }
     # Initialize a CDF File Wrapper
-    test_data = TimeData(ts, meta=input_attrs)
+    test_data = TimeData(ts, support=support, meta=input_attrs)
 
     # Add the Time column
     test_data["time"].meta.update(
@@ -476,8 +563,14 @@ def test_timedata_from_cdf():
     # fmt: on
 
     ts = get_test_timeseries()
+    support = {
+        "nrv_var": NDData(
+            data=[1, 2, 3],
+            meta={"CATDESC": "Test Metadata Variable", "VAR_TYPE": "metadata"},
+        )
+    }
     # Initialize a CDF File Wrapper
-    test_data = TimeData(ts, meta=input_attrs)
+    test_data = TimeData(ts, support=support, meta=input_attrs)
 
     # Add the Time column
     test_data["time"].meta.update(
@@ -547,6 +640,93 @@ def test_timedata_from_cdf():
         result2 = validate(test_file_output_path2)
         assert len(result2) <= 1  # Logical Source and File ID Do not Agree
         assert len(result) == len(result2)
+
+
+def test_timedata_idempotency():
+    # fmt: off
+    input_attrs = {
+        "DOI": "https://doi.org/<PREFIX>/<SUFFIX>",
+        "Data_level": "L1>Level 1",  # NOT AN ISTP ATTR
+        "Data_version": "0.0.1",
+        "Descriptor": "EEA>Electron Electrostatic Analyzer",
+        "Data_product_descriptor": "odpd",
+        "HTTP_LINK": [
+            "https://spdf.gsfc.nasa.gov/istp_guide/istp_guide.html",
+            "https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html",
+            "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html"
+        ],
+        "Instrument_mode": "default",  # NOT AN ISTP ATTR
+        "Instrument_type": "Electric Fields (space)",
+        "LINK_TEXT": [
+            "ISTP Guide",
+            "Global Attrs",
+            "Variable Attrs"
+        ],
+        "LINK_TITLE": [
+            "ISTP Guide",
+            "Global Attrs",
+            "Variable Attrs"
+        ],
+        "MODS": [
+            "v0.0.0 - Original version.",
+            "v1.0.0 - Include trajectory vectors and optics state.",
+            "v1.1.0 - Update metadata: counts -> flux.",
+            "v1.2.0 - Added flux error.",
+            "v1.3.0 - Trajectory vector errors are now deltas."
+        ],
+        "PI_affiliation": "HERMES",
+        "PI_name": "HERMES SOC",
+        "TEXT": "Valid Test Case",
+    }
+    # fmt: on
+    # Generate a base TimeData object
+    test_data = get_test_timedata()
+    test_data.meta.update(input_attrs)
+
+    # Induce a Bad (Null) Global Attribute
+    test_data.meta["Test Null Attr"] = ""
+
+    # Induce an Non-Record-Varying Variable
+    test_data.add_support(name="NRV_var", data=NDData(["Test NRV Data"]))
+
+    # Induce a Variable with Bad UNITS
+    test_data.add_support(
+        name="Bad_units_var", data=NDData([1, 2, 3, 4], meta={"UNITS": "Not A Unit"})
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        test_data_cols = test_data.columns
+        test_data_meta_keys = list(test_data.meta.keys())
+        test_file_output_path = test_data.save(output_path=tmpdirname)
+
+        # Try loading the *Invalid* CDF File
+        loaded_data = TimeData.load(test_file_output_path)
+
+        assert len(test_data) == len(loaded_data)
+        assert test_data.shape == loaded_data.shape
+        assert len(test_data.meta) == len(loaded_data.meta)
+
+        for attr in test_data.meta:
+            assert attr in loaded_data.meta
+
+        for var in test_data.columns:
+            assert var in loaded_data.columns
+            assert len(test_data[var]) == len(loaded_data[var])
+            assert len(test_data[var].meta) == len(loaded_data[var].meta)
+            assert test_data[var].meta["VAR_TYPE"] == loaded_data[var].meta["VAR_TYPE"]
+
+        for var in test_data.support:
+            assert var in loaded_data.support
+            assert (
+                test_data.support[var].data.shape == loaded_data.support[var].data.shape
+            )
+            assert len(test_data.support[var].meta) == len(
+                loaded_data.support[var].meta
+            )
+            assert (
+                test_data.support[var].meta["VAR_TYPE"]
+                == loaded_data.support[var].meta["VAR_TYPE"]
+            )
 
 
 @pytest.mark.parametrize(

--- a/hermes_core/timedata.py
+++ b/hermes_core/timedata.py
@@ -107,9 +107,15 @@ class HermesData:
 
         # Copy the Non-Record Varying Data
         if support:
-            self.support = support
+            self._support = support
         else:
-            self.support = {}
+            self._support = {}
+
+        # Copy the Non-Record Varying Data
+        if support:
+            self._support = support
+        else:
+            self._support = {}
 
         # Derive Metadata
         self.schema = HermesDataSchema()
@@ -121,6 +127,13 @@ class HermesData:
         (`astropy.timeseries.TimeSeries`) A `TimeSeries` representing one or more measurements as a function of time.
         """
         return self._timeseries
+
+    @property
+    def support(self):
+        """
+        (`dict[astropy.nddata.NDData]`) A `dict` containing one or more non-time-varying support variables.
+        """
+        return self._support
 
     @property
     def meta(self):
@@ -335,9 +348,9 @@ class HermesData:
                 )
 
         # Support/ Non-Record-Varying Data
-        for col in self.support:
+        for col in self._support:
             for attr_name, attr_value in self.schema.derive_measurement_attributes(
-                self.support, col
+                self._support, col
             ).items():
                 self._update_support_attribute(
                     var_name=col, attr_name=attr_name, attr_value=attr_value
@@ -385,22 +398,22 @@ class HermesData:
 
     def _update_support_attribute(self, var_name, attr_name, attr_value):
         if (
-            attr_name in self.support[var_name].meta
-            and self.support[var_name].meta[attr_name] is not None
+            attr_name in self._support[var_name].meta
+            and self._support[var_name].meta[attr_name] is not None
         ):
             attr_schema = self.schema.variable_attribute_schema["attribute_key"][
                 attr_name
             ]
             if (
-                self.support[var_name].meta[attr_name] != attr_value
+                self._support[var_name].meta[attr_name] != attr_value
                 and attr_schema["overwrite"]
             ):
                 warn_user(
-                    f"Overiding {var_name} Attribute {attr_name} : {self.support[var_name].meta[attr_name]} -> {attr_value}"
+                    f"Overiding {var_name} Attribute {attr_name} : {self._support[var_name].meta[attr_name]} -> {attr_value}"
                 )
-                self.support[var_name].meta[attr_name] = attr_value
+                self._support[var_name].meta[attr_name] = attr_value
         else:
-            self.support[var_name].meta[attr_name] = attr_value
+            self._support[var_name].meta[attr_name] = attr_value
 
     def add_measurement(self, measure_name: str, data: u.Quantity, meta: dict = None):
         """
@@ -462,10 +475,10 @@ class HermesData:
         if not isinstance(data, NDData):
             raise TypeError(f"Measurement {name} must be type `astropy.nddata.NDData`.")
 
-        self.support[name] = data
+        self._support[name] = data
         # Add any Metadata Passed not in the NDData
         if meta:
-            self.support[name].meta.update(meta)
+            self._support[name].meta.update(meta)
 
         # Derive Metadata Attributes for the Measurement
         self._derive_metadata()
@@ -481,8 +494,8 @@ class HermesData:
         """
         if measure_name in self._timeseries.columns:
             self._timeseries.remove_column(measure_name)
-        elif measure_name in self.support:
-            self.support.pop(measure_name)
+        elif measure_name in self._support:
+            self._support.pop(measure_name)
         else:
             raise ValueError(f"Data for Measurement {measure_name} not found.")
 

--- a/hermes_core/timedata.py
+++ b/hermes_core/timedata.py
@@ -25,7 +25,7 @@ class HermesData:
 
     Parameters
     ----------
-    data :  `astropy.timeseries.TimeSeries`
+    timeseries :  `astropy.timeseries.TimeSeries`
         The time series of data. Columns must be `~astropy.units.Quantity` arrays.
     support : `dict[astropy.nddata.NDData]`, optional
         Non-Record-Varying data associated with the timeseries data.
@@ -40,7 +40,7 @@ class HermesData:
     >>> data = u.Quantity([1, 2, 3, 4], "gauss", dtype=np.uint16)
     >>> ts = TimeSeries(time_start="2016-03-22T12:30:31", time_delta=3 * u.s, data={"Bx": data})
     >>> input_attrs = HermesData.global_attribute_template("eea", "l1", "1.0.0")
-    >>> hermes_data = HermesData(data=ts, meta=input_attrs)
+    >>> hermes_data = HermesData(timeseries=ts, meta=input_attrs)
 
     Raises
     ------
@@ -56,22 +56,24 @@ class HermesData:
     * `Space Physics Guidelines for CDF (ISTP) <https://spdf.gsfc.nasa.gov/istp_guide/istp_guide.html>`_
     """
 
-    def __init__(self, data, support=None, meta=None):
+    def __init__(self, timeseries, support=None, meta=None):
         # Verify TimeSeries compliance
-        if not isinstance(data, TimeSeries):
-            raise TypeError("Data must be a TimeSeries object.")
-        if len(data.columns) < 2:
-            raise ValueError("Data must have at least 2 columns")
+        if not isinstance(timeseries, TimeSeries):
+            raise TypeError(
+                "timeseries must be a `astropy.timeseries.TimeSeries` object."
+            )
+        if len(timeseries.columns) < 2:
+            raise ValueError("timeseries must have at least 2 columns")
 
         # Check individual Columns
-        for colname in data.columns:
+        for colname in timeseries.columns:
             # Verify that all Measurements are `Quantity`
-            if colname != "time" and not isinstance(data[colname], u.Quantity):
+            if colname != "time" and not isinstance(timeseries[colname], u.Quantity):
                 raise TypeError(
                     f"Column '{colname}' must be an astropy.units.Quantity object"
                 )
             # Verify that the Column is only a single dimension
-            if len(data[colname].shape) > 1:  # If there is more than 1 Dimension
+            if len(timeseries[colname].shape) > 1:  # If there is more than 1 Dimension
                 raise ValueError(
                     f"Column '{colname}' must be a one-dimensional measurement. Split additional dimensions into unique measurenents."
                 )
@@ -85,23 +87,23 @@ class HermesData:
                     )
 
         # Copy the TimeSeries
-        self._data = TimeSeries(data, copy=True)
+        self._timeseries = TimeSeries(timeseries, copy=True)
 
         # Add Input Metadata
         if meta is not None and isinstance(meta, dict):
-            self._data.meta.update(meta)
+            self._timeseries.meta.update(meta)
 
         # Add any Metadata from the original TimeSeries
-        self._data["time"].meta = OrderedDict()
-        if hasattr(data["time"], "meta"):
-            self._data["time"].meta.update(data["time"].meta)
+        self._timeseries["time"].meta = OrderedDict()
+        if hasattr(timeseries["time"], "meta"):
+            self._timeseries["time"].meta.update(timeseries["time"].meta)
 
         # Add Measurement Metadata
-        for col in self._data.columns:
+        for col in self._timeseries.columns:
             if col != "time":
-                self._data[col].meta = self.measurement_attribute_template()
-                if hasattr(data[col], "meta"):
-                    self._data[col].meta.update(data[col].meta)
+                self._timeseries[col].meta = self.measurement_attribute_template()
+                if hasattr(timeseries[col], "meta"):
+                    self._timeseries[col].meta.update(timeseries[col].meta)
 
         # Copy the Non-Record Varying Data
         if support:
@@ -114,18 +116,18 @@ class HermesData:
         self._derive_metadata()
 
     @property
-    def data(self):
+    def timeseries(self):
         """
         (`astropy.timeseries.TimeSeries`) A `TimeSeries` representing one or more measurements as a function of time.
         """
-        return self._data
+        return self._timeseries
 
     @property
     def meta(self):
         """
         (`collections.OrderedDict`) Global metadata associated with the measurement data.
         """
-        return self._data.meta
+        return self._timeseries.meta
 
     @property
     def units(self):
@@ -133,8 +135,8 @@ class HermesData:
         (`collections.OrderedDict`) The units of the measurement for each column in the `TimeSeries` table.
         """
         units = {}
-        for name in self._data.columns:
-            var_data = self._data[name]
+        for name in self._timeseries.columns:
+            var_data = self._timeseries[name]
             # Get the Unit
             if hasattr(var_data, "unit"):
                 unit = var_data.unit
@@ -148,14 +150,14 @@ class HermesData:
         """
         (`list`) A list of all the names of the columns in data.
         """
-        return self._data.colnames
+        return self._timeseries.colnames
 
     @property
     def time(self):
         """
         (`astropy.time.Time`) The times of the measurements.
         """
-        t = Time(self._data.time)
+        t = Time(self._timeseries.time)
         # Set time format to enable plotting with astropy.visualisation.time_support()
         t.format = "iso"
         return t
@@ -165,15 +167,15 @@ class HermesData:
         """
         (`tuple`) The start and end times of the times.
         """
-        return (self._data.time.min(), self._data.time.max())
+        return (self._timeseries.time.min(), self._timeseries.time.max())
 
     @property
     def shape(self):
         """
         (`tuple`) The shape of the data, a tuple (nrows, ncols) including time
         """
-        nrows = self._data.time.shape[0]
-        ncols = len(self._data.columns)
+        nrows = self._timeseries.time.shape[0]
+        ncols = len(self._timeseries.columns)
         return (nrows, ncols)
 
     def __repr__(self):
@@ -189,26 +191,26 @@ class HermesData:
         str_repr = f"HermesData() Object:\n"
         # Global Attributes/Metedata
         str_repr += f"Global Attrs:\n"
-        for attr_name, attr_value in self._data.meta.items():
+        for attr_name, attr_value in self._timeseries.meta.items():
             str_repr += f"\t{attr_name}: {attr_value}\n"
         # Measurement Data
-        str_repr += f"Measurement Data:\n{self._data}\n"
+        str_repr += f"Measurement Data:\n{self._timeseries}\n"
         return str_repr
 
     def __len__(self):
         """
         Function to get the number of measurements.
         """
-        return len(self._data.keys())
+        return len(self._timeseries.keys())
 
     def __getitem__(self, name):
         """
         Function to get a measurement.
         """
-        if name not in self._data.colnames:
+        if name not in self._timeseries.colnames:
             raise KeyError(f"Can't find data measurement {name}")
         # Get the Data and Attrs for the named measurement
-        var_data = self._data[name]
+        var_data = self._timeseries[name]
         return var_data
 
     def __setitem__(self, name, data):
@@ -223,14 +225,14 @@ class HermesData:
         """
         Function to see whether a measurement is in the class.
         """
-        return name in self._data.columns
+        return name in self._timeseries.columns
 
     def __iter__(self):
         """
         Function to iterate over data measurements and attributes.
         """
-        for name in self._data.columns:
-            var_data = self._data[name]
+        for name in self._timeseries.columns:
+            var_data = self._timeseries[name]
 
             yield (name, var_data)
 
@@ -311,24 +313,24 @@ class HermesData:
 
         # Global Attributes
         for attr_name, attr_value in self.schema.derive_global_attributes(
-            self._data
+            self._timeseries
         ).items():
             self._update_global_attribute(attr_name, attr_value)
 
         # Time Measurement Attributes
         for attr_name, attr_value in self.schema.derive_time_attributes(
-            self._data
+            self._timeseries
         ).items():
-            self._update_data_attribute(
+            self._update_timeseries_attribute(
                 var_name="time", attr_name=attr_name, attr_value=attr_value
             )
 
         # Other Measurement Attributes
-        for col in [col for col in self._data.columns if col != "time"]:
+        for col in [col for col in self._timeseries.columns if col != "time"]:
             for attr_name, attr_value in self.schema.derive_measurement_attributes(
-                self._data, col
+                self._timeseries, col
             ).items():
-                self._update_data_attribute(
+                self._update_timeseries_attribute(
                     var_name=col, attr_name=attr_name, attr_value=attr_value
                 )
 
@@ -343,40 +345,43 @@ class HermesData:
 
     def _update_global_attribute(self, attr_name, attr_value):
         # If the attribute is set, check if we want to overwrite it
-        if attr_name in self._data.meta and self._data.meta[attr_name] is not None:
+        if (
+            attr_name in self._timeseries.meta
+            and self._timeseries.meta[attr_name] is not None
+        ):
             # We want to overwrite if:
             #   1) The actual value is not the derived value
             #   2) The schema marks this attribute to be overwriten
             if (
-                self._data.meta[attr_name] != attr_value
+                self._timeseries.meta[attr_name] != attr_value
                 and self.schema.global_attribute_schema[attr_name]["overwrite"]
             ):
                 warn_user(
-                    f"Overiding Global Attribute {attr_name} : {self._data.meta[attr_name]} -> {attr_value}"
+                    f"Overiding Global Attribute {attr_name} : {self._timeseries.meta[attr_name]} -> {attr_value}"
                 )
-                self._data.meta[attr_name] = attr_value
+                self._timeseries.meta[attr_name] = attr_value
         # If the attribute is not set, set it
         else:
-            self._data.meta[attr_name] = attr_value
+            self._timeseries.meta[attr_name] = attr_value
 
-    def _update_data_attribute(self, var_name, attr_name, attr_value):
+    def _update_timeseries_attribute(self, var_name, attr_name, attr_value):
         if (
-            attr_name in self.data[var_name].meta
-            and self.data[var_name].meta[attr_name] is not None
+            attr_name in self.timeseries[var_name].meta
+            and self.timeseries[var_name].meta[attr_name] is not None
         ):
             attr_schema = self.schema.variable_attribute_schema["attribute_key"][
                 attr_name
             ]
             if (
-                self.data[var_name].meta[attr_name] != attr_value
+                self.timeseries[var_name].meta[attr_name] != attr_value
                 and attr_schema["overwrite"]
             ):
                 warn_user(
-                    f"Overiding {var_name} Attribute {attr_name} : {self.data[var_name].meta[attr_name]} -> {attr_value}"
+                    f"Overiding {var_name} Attribute {attr_name} : {self.timeseries[var_name].meta[attr_name]} -> {attr_value}"
                 )
-                self.data[var_name].meta[attr_name] = attr_value
+                self.timeseries[var_name].meta[attr_name] = attr_value
         else:
-            self.data[var_name].meta[attr_name] = attr_value
+            self.timeseries[var_name].meta[attr_name] = attr_value
 
     def _update_support_attribute(self, var_name, attr_name, attr_value):
         if (
@@ -425,13 +430,13 @@ class HermesData:
                 f"Column '{measure_name}' must be a one-dimensional measurement. Split additional dimensions into unique measurenents."
             )
 
-        self._data[measure_name] = data
+        self._timeseries[measure_name] = data
         # Add any Metadata from the original Quantity
-        self._data[measure_name].meta = self.measurement_attribute_template()
+        self._timeseries[measure_name].meta = self.measurement_attribute_template()
         if hasattr(data, "meta"):
-            self._data[measure_name].meta.update(data.meta)
+            self._timeseries[measure_name].meta.update(data.meta)
         if meta:
-            self._data[measure_name].meta.update(meta)
+            self._timeseries[measure_name].meta.update(meta)
 
         # Derive Metadata Attributes for the Measurement
         self._derive_metadata()
@@ -474,8 +479,8 @@ class HermesData:
         measure_name: `str`
             Name of the measurement to remove.
         """
-        if measure_name in self._data.columns:
-            self._data.remove_column(measure_name)
+        if measure_name in self._timeseries.columns:
+            self._timeseries.remove_column(measure_name)
         elif measure_name in self.support:
             self.support.pop(measure_name)
         else:
@@ -523,8 +528,8 @@ class HermesData:
                         f'{self.meta["Mission_group"]} {self.meta["Descriptor"]} {self.meta["Data_level"]}'
                     )
                     i += 1
-                this_ax.plot(self.time, self.data[this_col], **plot_args)
-                this_ax.set_ylabel(self.data[this_col].meta["LABLAXIS"])
+                this_ax.plot(self.time, self.timeseries[this_col], **plot_args)
+                this_ax.set_ylabel(self.timeseries[this_col].meta["LABLAXIS"])
         else:
             axes.set_title(
                 f'{self.meta["Mission_group"]} {self.meta["Descriptor"]} {self.meta["Data_level"]}'
@@ -532,8 +537,8 @@ class HermesData:
             for this_col in columns:
                 axes.plot(
                     self.time,
-                    self.data[this_col],
-                    label=self.data[this_col].meta["LABLAXIS"],
+                    self.timeseries[this_col],
+                    label=self.timeseries[this_col].meta["LABLAXIS"],
                     **plot_args,
                 )
             axes.legend()
@@ -579,44 +584,46 @@ class HermesData:
         locator = ax.xaxis.get_major_locator()
         ax.xaxis.set_major_formatter(mdates.ConciseDateFormatter(locator))
 
-    def append(self, data: TimeSeries):
+    def append(self, timeseries: TimeSeries):
         """
         Add additional measurements to an existing column.
 
         Parameters
         ----------
-        data : `astropy.timeseries.TimeSeries`
+        timeseries : `astropy.timeseries.TimeSeries`
             The data to be appended (rows) as a `TimeSeries` object.
         """
         # Verify TimeSeries compliance
-        if not isinstance(data, TimeSeries):
+        if not isinstance(timeseries, TimeSeries):
             raise TypeError("Data must be a TimeSeries object.")
-        if len(data.columns) < 2:
+        if len(timeseries.columns) < 2:
             raise ValueError("Data must have at least 2 columns")
-        if len(self.data.columns) != len(data.columns):
+        if len(self.timeseries.columns) != len(timeseries.columns):
             raise ValueError(
                 (
                     f"Shape of curent TimeSeries ({self.shape}) does not match",
-                    f"shape of data to add ({len(data.columns)}).",
+                    f"shape of data to add ({len(timeseries.columns)}).",
                 )
             )
 
         # Check individual Columns
-        for colname in self.data.columns:
-            if colname != "time" and not isinstance(self.data[colname], u.Quantity):
+        for colname in self.timeseries.columns:
+            if colname != "time" and not isinstance(
+                self.timeseries[colname], u.Quantity
+            ):
                 raise TypeError(
                     f"Column '{colname}' must be an astropy.Quantity object"
                 )
 
         # Save Metadata since it is not carried over with vstack
-        metadata_holder = {col: self.data[col].meta for col in self.columns}
+        metadata_holder = {col: self.timeseries[col].meta for col in self.columns}
 
         # Vertically Stack the TimeSeries
-        self._data = vstack([self._data, data])
+        self._timeseries = vstack([self._timeseries, timeseries])
 
         # Add Metadata back to the Stacked TimeSeries
         for col in self.columns:
-            self.data[col].meta = metadata_holder[col]
+            self.timeseries[col].meta = metadata_holder[col]
 
         # Re-Derive Metadata
         self._derive_metadata()
@@ -676,5 +683,5 @@ class HermesData:
             raise ValueError(f"Unsupported file type: {file_extension}")
 
         # Load data using the handler and return a HermesData object
-        data, support = handler.load_data(file_path)
-        return cls(data=data, support=support)
+        timeseries, support = handler.load_data(file_path)
+        return cls(timeseries=timeseries, support=support)

--- a/hermes_core/timedata.py
+++ b/hermes_core/timedata.py
@@ -130,6 +130,13 @@ class HermesData:
         return self._support
 
     @property
+    def data(self):
+        """
+        (`dict`) A `dict` containing each of `timeseries` and `support`.
+        """
+        return {"timeseries": self.timeseries, "support": self.support}
+
+    @property
     def meta(self):
         """
         (`collections.OrderedDict`) Global metadata associated with the measurement data.

--- a/hermes_core/timedata.py
+++ b/hermes_core/timedata.py
@@ -59,7 +59,9 @@ class HermesData:
     def __init__(self, timeseries, support=None, meta=None):
         # Verify TimeSeries compliance
         if not isinstance(timeseries, TimeSeries):
-            raise TypeError("timeseries must be a `astropy.timeseries.TimeSeries` object.")
+            raise TypeError(
+                "timeseries must be a `astropy.timeseries.TimeSeries` object."
+            )
         if len(timeseries.columns) < 2:
             raise ValueError("timeseries must have at least 2 columns")
 
@@ -67,7 +69,9 @@ class HermesData:
         for colname in timeseries.columns:
             # Verify that all Measurements are `Quantity`
             if colname != "time" and not isinstance(timeseries[colname], u.Quantity):
-                raise TypeError(f"Column '{colname}' must be an astropy.units.Quantity object")
+                raise TypeError(
+                    f"Column '{colname}' must be an astropy.units.Quantity object"
+                )
             # Verify that the Column is only a single dimension
             if len(timeseries[colname].shape) > 1:  # If there is more than 1 Dimension
                 raise ValueError(
@@ -78,7 +82,9 @@ class HermesData:
         if support:
             for key in support:
                 if not (isinstance(support[key], NDData)):
-                    raise TypeError(f"Variable '{key}' must be an astropy.nddata.NDData object")
+                    raise TypeError(
+                        f"Variable '{key}' must be an astropy.nddata.NDData object"
+                    )
 
         # Copy the TimeSeries
         self._timeseries = TimeSeries(timeseries, copy=True)
@@ -98,18 +104,6 @@ class HermesData:
                 self._timeseries[col].meta = self.measurement_attribute_template()
                 if hasattr(timeseries[col], "meta"):
                     self._timeseries[col].meta.update(timeseries[col].meta)
-
-        # Copy the Non-Record Varying Data
-        if support:
-            self._support = support
-        else:
-            self._support = {}
-
-        # Copy the Non-Record Varying Data
-        if support:
-            self._support = support
-        else:
-            self._support = {}
 
         # Copy the Non-Record Varying Data
         if support:
@@ -206,7 +200,9 @@ class HermesData:
                     f"Instrument, {instr_name}, is not recognized. Must be one of {hermes_core.INST_NAMES}."
                 )
             # Set the Property
-            meta["Descriptor"] = f"{instr_name.upper()}>{hermes_core.INST_TO_FULLNAME[instr_name]}"
+            meta[
+                "Descriptor"
+            ] = f"{instr_name.upper()}>{hermes_core.INST_TO_FULLNAME[instr_name]}"
 
         # Check the Optional Data Level
         if data_level:
@@ -224,7 +220,9 @@ class HermesData:
         if version:
             # check that version is in the right format with three parts
             if len(version.split(".")) != 3:
-                raise ValueError(f"Version, {version}, is not formatted correctly. Should be X.Y.Z")
+                raise ValueError(
+                    f"Version, {version}, is not formatted correctly. Should be X.Y.Z"
+                )
             meta["Data_version"] = version
         return meta
 
@@ -250,11 +248,15 @@ class HermesData:
             self._update_global_attribute(attr_name, attr_value)
 
         # Global Attributes
-        for attr_name, attr_value in self.schema.derive_global_attributes(self._timeseries).items():
+        for attr_name, attr_value in self.schema.derive_global_attributes(
+            self._timeseries
+        ).items():
             self._update_global_attribute(attr_name, attr_value)
 
         # Time Measurement Attributes
-        for attr_name, attr_value in self.schema.derive_time_attributes(self._timeseries).items():
+        for attr_name, attr_value in self.schema.derive_time_attributes(
+            self._timeseries
+        ).items():
             self._update_timeseries_attribute(
                 var_name="time", attr_name=attr_name, attr_value=attr_value
             )
@@ -279,7 +281,10 @@ class HermesData:
 
     def _update_global_attribute(self, attr_name, attr_value):
         # If the attribute is set, check if we want to overwrite it
-        if attr_name in self._timeseries.meta and self._timeseries.meta[attr_name] is not None:
+        if (
+            attr_name in self._timeseries.meta
+            and self._timeseries.meta[attr_name] is not None
+        ):
             # We want to overwrite if:
             #   1) The actual value is not the derived value
             #   2) The schema marks this attribute to be overwriten
@@ -300,8 +305,13 @@ class HermesData:
             attr_name in self.timeseries[var_name].meta
             and self.timeseries[var_name].meta[attr_name] is not None
         ):
-            attr_schema = self.schema.variable_attribute_schema["attribute_key"][attr_name]
-            if self.timeseries[var_name].meta[attr_name] != attr_value and attr_schema["overwrite"]:
+            attr_schema = self.schema.variable_attribute_schema["attribute_key"][
+                attr_name
+            ]
+            if (
+                self.timeseries[var_name].meta[attr_name] != attr_value
+                and attr_schema["overwrite"]
+            ):
                 warn_user(
                     f"Overiding {var_name} Attribute {attr_name} : {self.timeseries[var_name].meta[attr_name]} -> {attr_value}"
                 )
@@ -314,8 +324,13 @@ class HermesData:
             attr_name in self._support[var_name].meta
             and self._support[var_name].meta[attr_name] is not None
         ):
-            attr_schema = self.schema.variable_attribute_schema["attribute_key"][attr_name]
-            if self._support[var_name].meta[attr_name] != attr_value and attr_schema["overwrite"]:
+            attr_schema = self.schema.variable_attribute_schema["attribute_key"][
+                attr_name
+            ]
+            if (
+                self._support[var_name].meta[attr_name] != attr_value
+                and attr_schema["overwrite"]
+            ):
                 warn_user(
                     f"Overiding {var_name} Attribute {attr_name} : {self._support[var_name].meta[attr_name]} -> {attr_value}"
                 )
@@ -530,11 +545,17 @@ class HermesData:
 
         # Check individual Columns
         for colname in self.timeseries.columns:
-            if colname != "time" and not isinstance(self.timeseries[colname], u.Quantity):
-                raise TypeError(f"Column '{colname}' must be an astropy.Quantity object")
+            if colname != "time" and not isinstance(
+                self.timeseries[colname], u.Quantity
+            ):
+                raise TypeError(
+                    f"Column '{colname}' must be an astropy.Quantity object"
+                )
 
         # Save Metadata since it is not carried over with vstack
-        metadata_holder = {col: self.timeseries[col].meta for col in self.timeseries.columns}
+        metadata_holder = {
+            col: self.timeseries[col].meta for col in self.timeseries.columns
+        }
 
         # Vertically Stack the TimeSeries
         self._timeseries = vstack([self._timeseries, timeseries])

--- a/hermes_core/timedata.py
+++ b/hermes_core/timedata.py
@@ -12,7 +12,7 @@ from astropy.nddata import NDData
 from astropy import units as u
 import hermes_core
 from hermes_core.util.io import CDFHandler
-from hermes_core.util.schema import HERMESDataSchema
+from hermes_core.util.schema import HermesDataSchema
 from hermes_core.util.exceptions import warn_user
 from hermes_core.util.util import VALID_DATA_LEVELS
 
@@ -110,7 +110,7 @@ class HermesData:
             self.support = {}
 
         # Derive Metadata
-        self.schema = HERMESDataSchema()
+        self.schema = HermesDataSchema()
         self._derive_metadata()
 
     @property
@@ -253,7 +253,7 @@ class HermesData:
         template : `collections.OrderedDict`
             A template for required global attributes.
         """
-        meta = HERMESDataSchema.global_attribute_template()
+        meta = HermesDataSchema.global_attribute_template()
 
         # Check the Optional Instrument Name
         if instr_name:
@@ -298,11 +298,11 @@ class HermesData:
         template : `collections.OrderedDict`
             A template for required variable attributes that must be provided.
         """
-        return HERMESDataSchema.measurement_attribute_template()
+        return HermesDataSchema.measurement_attribute_template()
 
     def _derive_metadata(self):
         """
-        Funtion to derive global and measurement metadata based on a HERMESDataSchema
+        Funtion to derive global and measurement metadata based on a HermesDataSchema
         """
 
         # Get Default Metadata

--- a/hermes_core/timedata.py
+++ b/hermes_core/timedata.py
@@ -8,6 +8,7 @@ import numpy as np
 from astropy.time import Time
 from astropy.timeseries import TimeSeries
 from astropy.table import vstack
+from astropy.nddata import NDData
 from astropy import units as u
 import hermes_core
 from hermes_core.util.io import CDFHandler
@@ -26,6 +27,8 @@ class TimeData:
     ----------
     data :  `astropy.timeseries.TimeSeries`
         The time series of data. Columns must be `~astropy.units.Quantity` arrays.
+    support : `dict[astropy.nddata.NDData]`, optional
+        Non-Record-Varying data associated with the timeseries data.
     meta : `dict`, optional
         The metadata describing the time series in an ISTP-compliant format.
 
@@ -53,7 +56,7 @@ class TimeData:
     * `Space Physics Guidelines for CDF (ISTP) <https://spdf.gsfc.nasa.gov/istp_guide/istp_guide.html>`_
     """
 
-    def __init__(self, data, meta=None):
+    def __init__(self, data, support=None, meta=None):
         # Verify TimeSeries compliance
         if not isinstance(data, TimeSeries):
             raise TypeError("Data must be a TimeSeries object.")
@@ -65,13 +68,21 @@ class TimeData:
             # Verify that all Measurements are `Quantity`
             if colname != "time" and not isinstance(data[colname], u.Quantity):
                 raise TypeError(
-                    f"Column '{colname}' must be an astropy.Quantity object"
+                    f"Column '{colname}' must be an astropy.units.Quantity object"
                 )
             # Verify that the Column is only a single dimension
             if len(data[colname].shape) > 1:  # If there is more than 1 Dimension
                 raise ValueError(
                     f"Column '{colname}' must be a one-dimensional measurement. Split additional dimensions into unique measurenents."
                 )
+
+        # Check NRV Data
+        if support:
+            for colname in support:
+                if not (isinstance(support[colname], NDData)):
+                    raise TypeError(
+                        f"Variable '{colname}' must be an astropy.nddata.NDData object"
+                    )
 
         # Copy the TimeSeries
         self._data = TimeSeries(data, copy=True)
@@ -91,6 +102,12 @@ class TimeData:
                 self._data[col].meta = self.measurement_attribute_template()
                 if hasattr(data[col], "meta"):
                     self._data[col].meta.update(data[col].meta)
+
+        # Copy the Non-Record Varying Data
+        if support:
+            self.support = support
+        else:
+            self.support = {}
 
         # Derive Metadata
         self.schema = HERMESDataSchema()
@@ -118,14 +135,11 @@ class TimeData:
         units = {}
         for name in self._data.columns:
             var_data = self._data[name]
-
             # Get the Unit
             if hasattr(var_data, "unit"):
                 unit = var_data.unit
-            elif "UNITS" in var_data.meta and var_data.meta["UNITS"]:
-                unit = var_data.meta["UNITS"]
             else:
-                unit = None
+                unit = var_data.meta["UNITS"]
             units[name] = unit
         return OrderedDict(units)
 
@@ -293,87 +307,99 @@ class TimeData:
 
         # Get Default Metadata
         for attr_name, attr_value in self.schema.default_global_attributes.items():
-            # If the attribute is set, check if we want to overwrite it
-            if attr_name in self._data.meta and self._data.meta[attr_name] is not None:
-                # We want to overwrite if:
-                #   1) The actual value is not the derived value
-                #   2) The schema marks this attribute to be overwriten
-                if (
-                    self._data.meta[attr_name] != attr_value
-                    and self.schema.global_attribute_schema[attr_name]["overwrite"]
-                ):
-                    warn_user(
-                        f"Overiding Global Attribute {attr_name} : {self._data.meta[attr_name]} -> {attr_value}"
-                    )
-                    self._data.meta[attr_name] = attr_value
-            # If the attribute is not set, set it
-            else:
-                self._data.meta[attr_name] = attr_value
+            self._update_global_attribute(attr_name, attr_value)
 
         # Global Attributes
         for attr_name, attr_value in self.schema.derive_global_attributes(
             self._data
         ).items():
-            if attr_name in self._data.meta and self._data.meta[attr_name] is not None:
-                if (
-                    self._data.meta[attr_name] != attr_value
-                    and self.schema.global_attribute_schema[attr_name]["overwrite"]
-                ):
-                    warn_user(
-                        f"Overiding Global Attribute {attr_name} : {self._data.meta[attr_name]} -> {attr_value}"
-                    )
-                    self._data.meta[attr_name] = attr_value
-            else:
-                self._data.meta[attr_name] = attr_value
+            self._update_global_attribute(attr_name, attr_value)
 
         # Time Measurement Attributes
         for attr_name, attr_value in self.schema.derive_time_attributes(
             self._data
         ).items():
-            if (
-                attr_name in self._data["time"].meta
-                and self._data["time"].meta[attr_name] is not None
-            ):
-                attr_schema = self.schema.variable_attribute_schema["attribute_key"][
-                    attr_name
-                ]
-                if (
-                    self._data["time"].meta[attr_name] != attr_value
-                    and attr_schema["overwrite"]
-                ):
-                    warn_user(
-                        f"Overiding Time Attribute {attr_name} : {self._data['time'].meta[attr_name]} -> {attr_value}"
-                    )
-                    self._data["time"].meta[attr_name] = attr_value
-            else:
-                self._data["time"].meta[attr_name] = attr_value
+            self._update_data_attribute(
+                var_name="time", attr_name=attr_name, attr_value=attr_value
+            )
 
         # Other Measurement Attributes
         for col in [col for col in self._data.columns if col != "time"]:
             for attr_name, attr_value in self.schema.derive_measurement_attributes(
                 self._data, col
             ).items():
-                if (
-                    attr_name in self._data[col].meta
-                    and self._data[col].meta[attr_name] is not None
-                ):
-                    attr_schema = self.schema.variable_attribute_schema[
-                        "attribute_key"
-                    ][attr_name]
-                    if (
-                        self._data[col].meta[attr_name] != attr_value
-                        and attr_schema["overwrite"]
-                    ):
-                        warn_user(
-                            f"Overiding Measurement Attribute {attr_name} : {self._data[col].meta[attr_name]} -> {attr_value}"
-                        )
-                        self._data[col].meta[attr_name] = attr_value
-                else:
-                    self._data[col].meta[attr_name] = attr_value
+                self._update_data_attribute(
+                    var_name=col, attr_name=attr_name, attr_value=attr_value
+                )
+
+        # Support/ Non-Record-Varying Data
+        for col in self.support:
+            for attr_name, attr_value in self.schema.derive_measurement_attributes(
+                self.support, col
+            ).items():
+                self._update_support_attribute(
+                    var_name=col, attr_name=attr_name, attr_value=attr_value
+                )
+
+    def _update_global_attribute(self, attr_name, attr_value):
+        # If the attribute is set, check if we want to overwrite it
+        if attr_name in self._data.meta and self._data.meta[attr_name] is not None:
+            # We want to overwrite if:
+            #   1) The actual value is not the derived value
+            #   2) The schema marks this attribute to be overwriten
+            if (
+                self._data.meta[attr_name] != attr_value
+                and self.schema.global_attribute_schema[attr_name]["overwrite"]
+            ):
+                warn_user(
+                    f"Overiding Global Attribute {attr_name} : {self._data.meta[attr_name]} -> {attr_value}"
+                )
+                self._data.meta[attr_name] = attr_value
+        # If the attribute is not set, set it
+        else:
+            self._data.meta[attr_name] = attr_value
+
+    def _update_data_attribute(self, var_name, attr_name, attr_value):
+        if (
+            attr_name in self.data[var_name].meta
+            and self.data[var_name].meta[attr_name] is not None
+        ):
+            attr_schema = self.schema.variable_attribute_schema["attribute_key"][
+                attr_name
+            ]
+            if (
+                self.data[var_name].meta[attr_name] != attr_value
+                and attr_schema["overwrite"]
+            ):
+                warn_user(
+                    f"Overiding {var_name} Attribute {attr_name} : {self.data[var_name].meta[attr_name]} -> {attr_value}"
+                )
+                self.data[var_name].meta[attr_name] = attr_value
+        else:
+            self.data[var_name].meta[attr_name] = attr_value
+
+    def _update_support_attribute(self, var_name, attr_name, attr_value):
+        if (
+            attr_name in self.support[var_name].meta
+            and self.support[var_name].meta[attr_name] is not None
+        ):
+            attr_schema = self.schema.variable_attribute_schema["attribute_key"][
+                attr_name
+            ]
+            if (
+                self.support[var_name].meta[attr_name] != attr_value
+                and attr_schema["overwrite"]
+            ):
+                warn_user(
+                    f"Overiding {var_name} Attribute {attr_name} : {self.support[var_name].meta[attr_name]} -> {attr_value}"
+                )
+                self.support[var_name].meta[attr_name] = attr_value
+        else:
+            self.support[var_name].meta[attr_name] = attr_value
 
     def add_measurement(self, measure_name: str, data: u.Quantity, meta: dict = None):
         """
-        Add a new measurement (column).
+        Add a new time-varying measurement (column).
 
         Parameters
         ----------
@@ -410,7 +436,36 @@ class TimeData:
         # Derive Metadata Attributes for the Measurement
         self._derive_metadata()
 
-    def remove_measurement(self, measure_name: str):
+    def add_support(self, name: str, data: NDData, meta: dict = None):
+        """
+        Add a new non-time-varying measurement (column).
+
+        Parameters
+        ----------
+        name: `str`
+            Name of the measurement to add.
+        data: `astropy.nddata.NDData`,
+            The data to add.
+        meta: `dict`, optional
+            The metadata associated with the measurement.
+
+        Raises
+        ------
+        TypeError: If var_data is not of type NDData.
+        """
+        # Verify that all Measurements are `NDData`
+        if not isinstance(data, NDData):
+            raise TypeError(f"Measurement {name} must be type `astropy.nddata.NDData`.")
+
+        self.support[name] = data
+        # Add any Metadata Passed not in the NDData
+        if meta:
+            self.support[name].meta.update(meta)
+
+        # Derive Metadata Attributes for the Measurement
+        self._derive_metadata()
+
+    def remove(self, measure_name: str):
         """
         Remove an existing measurement (column).
 
@@ -419,7 +474,12 @@ class TimeData:
         measure_name: `str`
             Name of the measurement to remove.
         """
-        self._data.remove_column(measure_name)
+        if measure_name in self._data.columns:
+            self._data.remove_column(measure_name)
+        elif measure_name in self.support:
+            self.support.pop(measure_name)
+        else:
+            raise ValueError(f"Data for Measurement {measure_name} not found.")
 
     def plot(self, axes=None, columns=None, subplots=True, **plot_args):
         """
@@ -616,5 +676,5 @@ class TimeData:
             raise ValueError(f"Unsupported file type: {file_extension}")
 
         # Load data using the handler and return a TimeData object
-        data = handler.load_data(file_path)
-        return cls(data)
+        data, support = handler.load_data(file_path)
+        return cls(data=data, support=support)

--- a/hermes_core/timedata.py
+++ b/hermes_core/timedata.py
@@ -16,10 +16,10 @@ from hermes_core.util.schema import HERMESDataSchema
 from hermes_core.util.exceptions import warn_user
 from hermes_core.util.util import VALID_DATA_LEVELS
 
-__all__ = ["TimeData"]
+__all__ = ["HermesData"]
 
 
-class TimeData:
+class HermesData:
     """
     A generic object for loading, storing, and manipulating HERMES time series data.
 
@@ -36,11 +36,11 @@ class TimeData:
     --------
     >>> import astropy.units as u
     >>> from astropy.timeseries import TimeSeries
-    >>> from hermes_core.timedata import TimeData
+    >>> from hermes_core.timedata import HermesData
     >>> data = u.Quantity([1, 2, 3, 4], "gauss", dtype=np.uint16)
     >>> ts = TimeSeries(time_start="2016-03-22T12:30:31", time_delta=3 * u.s, data={"Bx": data})
-    >>> input_attrs = TimeData.global_attribute_template("eea", "l1", "1.0.0")
-    >>> timedata = TimeData(data=ts, meta=input_attrs)
+    >>> input_attrs = HermesData.global_attribute_template("eea", "l1", "1.0.0")
+    >>> hermes_data = HermesData(data=ts, meta=input_attrs)
 
     Raises
     ------
@@ -178,15 +178,15 @@ class TimeData:
 
     def __repr__(self):
         """
-        Returns a representation of the `TimeData` class.
+        Returns a representation of the `HermesData` class.
         """
         return self.__str__()
 
     def __str__(self):
         """
-        Returns a string representation of the `TimeData` class.
+        Returns a string representation of the `HermesData` class.
         """
-        str_repr = f"TimeData() Object:\n"
+        str_repr = f"HermesData() Object:\n"
         # Global Attributes/Metedata
         str_repr += f"Global Attrs:\n"
         for attr_name, attr_value in self._data.meta.items():
@@ -658,8 +658,8 @@ class TimeData:
 
         Returns
         -------
-        data : `TimeData`
-            A `TimeData` object containing the loaded data.
+        data : `HermesData`
+            A `HermesData` object containing the loaded data.
 
         Raises
         ------
@@ -675,6 +675,6 @@ class TimeData:
         else:
             raise ValueError(f"Unsupported file type: {file_extension}")
 
-        # Load data using the handler and return a TimeData object
+        # Load data using the handler and return a HermesData object
         data, support = handler.load_data(file_path)
         return cls(data=data, support=support)

--- a/hermes_core/util/io.py
+++ b/hermes_core/util/io.py
@@ -6,7 +6,7 @@ from astropy.time import Time
 from astropy.nddata import NDData
 import astropy.units as u
 from hermes_core.util.exceptions import warn_user
-from hermes_core.util.schema import HERMESDataSchema
+from hermes_core.util.schema import HermesDataSchema
 
 __all__ = ["CDFHandler"]
 
@@ -68,7 +68,7 @@ class CDFHandler(HermesDataIOHandler):
         super().__init__()
 
         # CDF Schema
-        self.schema = HERMESDataSchema()
+        self.schema = HermesDataSchema()
 
     def load_data(self, file_path):
         """

--- a/hermes_core/util/io.py
+++ b/hermes_core/util/io.py
@@ -161,7 +161,9 @@ class CDFHandler(HermesDataIOHandler):
                             self._load_data_variable(ts, var_name, var_data, var_attrs)
                     else:
                         # Load as `support`
-                        self._load_support_variable(support, var_name, var_data, var_attrs)
+                        self._load_support_variable(
+                            support, var_name, var_data, var_attrs
+                        )
                 else:
                     # Load Non-Record-Varying Data as `support`
                     self._load_support_variable(support, var_name, var_data, var_attrs)

--- a/hermes_core/util/io.py
+++ b/hermes_core/util/io.py
@@ -15,7 +15,7 @@ __all__ = ["CDFHandler"]
 # ================================================================================================
 
 
-class TimeDataIOHandler(ABC):
+class HermesDataIOHandler(ABC):
     """
     Abstract base class for handling input/output operations of heliophysics data.
     """
@@ -44,8 +44,8 @@ class TimeDataIOHandler(ABC):
 
         Parameters
         ----------
-        data : `hermes_core.timedata.TimeData`
-            An instance of `TimeData` containing the data to be saved.
+        data : `hermes_core.timedata.HermesData`
+            An instance of `HermesData` containing the data to be saved.
         file_path : `str`
             The fully specified file path to save into.
         """
@@ -57,9 +57,9 @@ class TimeDataIOHandler(ABC):
 # ================================================================================================
 
 
-class CDFHandler(TimeDataIOHandler):
+class CDFHandler(HermesDataIOHandler):
     """
-    A concrete implementation of TimeDataIOHandler for handling heliophysics data in CDF format.
+    A concrete implementation of HermesDataIOHandler for handling heliophysics data in CDF format.
 
     This class provides methods to load and save heliophysics data from/to a CDF file.
     """
@@ -189,8 +189,8 @@ class CDFHandler(TimeDataIOHandler):
 
         Parameters
         ----------
-        data : `hermes_core.timedata.TimeData`
-            An instance of `TimeData` containing the data to be saved.
+        data : `hermes_core.timedata.HermesData`
+            An instance of `HermesData` containing the data to be saved.
         file_path : `str`
             The path to save the CDF file.
 

--- a/hermes_core/util/io.py
+++ b/hermes_core/util/io.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from collections import OrderedDict
 from astropy.timeseries import TimeSeries
 from astropy.time import Time
+from astropy.nddata import NDData
+import astropy.units as u
 from hermes_core.util.exceptions import warn_user
 from hermes_core.util.schema import HERMESDataSchema
 
@@ -81,6 +83,8 @@ class CDFHandler(TimeDataIOHandler):
         -------
         data : `~astropy.time.TimeSeries`
             An instance of `TimeSeries` containing the loaded data.
+        support : `dict`
+            Non-record-varying data contained in the file
         """
         from spacepy.pycdf import CDF
 
@@ -89,13 +93,18 @@ class CDFHandler(TimeDataIOHandler):
 
         # Create a new TimeSeries
         ts = TimeSeries()
+        # Create a Data Structure for Non-record Varying Data
+        support = {}
 
         # Open CDF file with context manager
         with CDF(file_path) as input_file:
             # Add Global Attributes from the CDF file to TimeSeries
             input_global_attrs = {}
             for attr_name in input_file.attrs:
-                if len(input_file.attrs[attr_name]) > 1:
+                if len(input_file.attrs[attr_name]) == 0:
+                    # gAttr is not set
+                    input_global_attrs[attr_name] = ""
+                elif len(input_file.attrs[attr_name]) > 1:
                     # gAttr is a List
                     input_global_attrs[attr_name] = input_file.attrs[attr_name][:]
                 else:
@@ -115,22 +124,64 @@ class CDFHandler(TimeDataIOHandler):
                 ts["time"].meta = OrderedDict()
                 ts["time"].meta.update(time_attrs)
 
+            # Get all the Keys for Measurement Variable Data
+            # These are Keys where the underlying object is a `dict` that contains
+            # additional data, and is not the `EPOCH` variable
+            variable_keys = filter(lambda key: key != "Epoch", list(input_file.keys()))
             # Add Variable Attributtes from the CDF file to TimeSeries
-            for var_name in input_file:
-                if var_name != "Epoch":  # Since we added this separately
-                    var_data = input_file[var_name][:].copy()
-                    var_attrs = {}
-                    for attr_name in input_file[var_name].attrs:
-                        var_attrs[attr_name] = input_file[var_name].attrs[attr_name]
-                    # Create the Quantity object
-                    ts[var_name] = var_data
-                    ts[var_name].unit = var_attrs["UNITS"]
-                    # Create the Metadata
-                    ts[var_name].meta = OrderedDict()
-                    ts[var_name].meta.update(var_attrs)
+            for var_name in variable_keys:
+                # Make sure the Variable is not multi-dimensional
+                if len(input_file[var_name].shape) > 1:
+                    warn_user(
+                        f"Measurement Variable {var_name} is multi-dimensional. Cannot add {var_name} to the TimeSeries"
+                    )
+                    # Skip to the next Variable
+                    continue
 
-        # Return the given TimeSeries
-        return ts
+                # Extract the Variable's Metadata
+                var_attrs = {}
+                for attr_name in input_file[var_name].attrs:
+                    var_attrs[attr_name] = input_file[var_name].attrs[attr_name]
+
+                # Extract the Variable's Data
+                var_data = input_file[var_name][...]
+                if input_file[var_name].rv():
+                    # See if it is record-varying data with Units
+                    if "UNITS" in var_attrs and len(var_data) == len(ts["time"]):
+                        # Load as Record-Varying `data`
+                        try:
+                            self._load_data_variable(ts, var_name, var_data, var_attrs)
+                        except ValueError:
+                            warn_user(
+                                f"Cannot create Quantity for Variable {var_name} with UNITS {var_attrs['UNITS']}. Creating Quantity with UNITS {u.dimensionless_unscaled}."
+                            )
+                            # Swap Units
+                            var_attrs["UNITS_DESC"] = var_attrs["UNITS"]
+                            var_attrs["UNITS"] = u.dimensionless_unscaled.to_string()
+                            self._load_data_variable(ts, var_name, var_data, var_attrs)
+                    else:
+                        # Load as `support`
+                        self._load_support_variable(
+                            support, var_name, var_data, var_attrs
+                        )
+                else:
+                    # Load Non-Record-Varying Data as `support`
+                    self._load_support_variable(support, var_name, var_data, var_attrs)
+
+        # Return the given TimeSeries, NRV Data
+        return ts, support
+
+    def _load_data_variable(self, ts, var_name, var_data, var_attrs):
+        # Create the Quantity object
+        var_data = u.Quantity(value=var_data, unit=var_attrs["UNITS"], copy=False)
+        ts[var_name] = var_data
+        # Create the Metadata
+        ts[var_name].meta = OrderedDict()
+        ts[var_name].meta.update(var_attrs)
+
+    def _load_support_variable(self, support, var_name, var_data, var_attrs):
+        # Create a NDData entry for the variable
+        support[var_name] = NDData(data=var_data, meta=var_attrs)
 
     def save_data(self, data, file_path):
         """
@@ -173,7 +224,7 @@ class CDFHandler(TimeDataIOHandler):
                 cdf_file.attrs[attr_name] = attr_value
 
     def _convert_variable_attributes_to_cdf(self, data, cdf_file):
-        # Loop through Variable Attributes in target_dict
+        # Loop through Variable Attributes
         for var_name, var_data in data.__iter__():
             if var_name == "time":
                 # Add 'time' in the TimeSeries as 'Epoch' within the CDF
@@ -193,3 +244,26 @@ class CDFHandler(TimeDataIOHandler):
                     else:
                         # Add the Attribute to the CDF File
                         cdf_file[var_name].attrs[var_attr_name] = var_attr_val
+
+        # Loop through Non-Record-Varying Data
+        for var_name, var_data in data.support.items():
+            # Guess the data type to store
+            # Documented in https://github.com/spacepy/spacepy/issues/707
+            _, var_data_types, _ = self.schema._types(var_data.data)
+            # Add the Variable to the CDF File
+            cdf_file.new(
+                name=var_name,
+                data=var_data.data,
+                type=var_data_types[0],
+                recVary=False,
+            )
+
+            # Add the Variable Attributes
+            for var_attr_name, var_attr_val in var_data.meta.items():
+                if var_attr_val is None:
+                    raise ValueError(
+                        f"Variable {var_name}: Cannot Add vAttr: {var_attr_name}. Value was {str(var_attr_val)}"
+                    )
+                else:
+                    # Add the Attribute to the CDF File
+                    cdf_file[var_name].attrs[var_attr_name] = var_attr_val

--- a/hermes_core/util/io.py
+++ b/hermes_core/util/io.py
@@ -153,7 +153,7 @@ class CDFHandler(HermesDataIOHandler):
                             self._load_data_variable(ts, var_name, var_data, var_attrs)
                         except ValueError:
                             warn_user(
-                                f"Cannot create Quantity for Variable {var_name} with UNITS {var_attrs['UNITS']}. Creating Quantity with UNITS {u.dimensionless_unscaled}."
+                                f"Cannot create Quantity for Variable {var_name} with UNITS {var_attrs['UNITS']}. Creating Quantity with UNITS 'dimensionless_unscaled'."
                             )
                             # Swap Units
                             var_attrs["UNITS_DESC"] = var_attrs["UNITS"]
@@ -225,7 +225,8 @@ class CDFHandler(HermesDataIOHandler):
 
     def _convert_variable_attributes_to_cdf(self, data, cdf_file):
         # Loop through Variable Attributes
-        for var_name, var_data in data.__iter__():
+        for var_name in data.timeseries.colnames:
+            var_data = data.timeseries[var_name]
             if var_name == "time":
                 # Add 'time' in the TimeSeries as 'Epoch' within the CDF
                 cdf_file["Epoch"] = var_data.to_datetime()

--- a/hermes_core/util/schema.py
+++ b/hermes_core/util/schema.py
@@ -643,8 +643,8 @@ class HERMESDataSchema:
 
         Parameters
         ----------
-        data : `hermes_core.timedata.TimeData`
-            An instance of `TimeData` to derive metadata from
+        data : `hermes_core.timedata.HermesData`
+            An instance of `HermesData` to derive metadata from
         var_name : `str`
             The name of the measurement to derive metadata for
         guess_types : `list[int]`, optional
@@ -726,8 +726,8 @@ class HERMESDataSchema:
 
         Parameters
         ----------
-        data : `hermes_core.timedata.TimeData`
-            An instance of `TimeData` to derive metadata from.
+        data : `hermes_core.timedata.HermesData`
+            An instance of `HermesData` to derive metadata from.
 
         Returns
         -------
@@ -758,8 +758,8 @@ class HERMESDataSchema:
 
         Parameters
         ----------
-        data : `hermes_core.timedata.TimeData`
-            An instance of `TimeData` to derive metadata from.
+        data : `hermes_core.timedata.HermesData`
+            An instance of `HermesData` to derive metadata from.
 
         Returns
         -------

--- a/hermes_core/util/schema.py
+++ b/hermes_core/util/schema.py
@@ -17,6 +17,7 @@ from astropy import units as u
 import hermes_core
 from hermes_core import log
 from hermes_core.util import util, const
+from hermes_core.util.exceptions import warn_user
 
 __all__ = ["HERMESDataSchema"]
 
@@ -664,25 +665,59 @@ class HERMESDataSchema:
                 (guess_dims, guess_types, guess_elements) = self._types(
                     var_data.to_datetime()
                 )
-            else:
+            elif hasattr(var_data, "value"):
                 # Guess the const CDF Data Type
                 (guess_dims, guess_types, guess_elements) = self._types(var_data.value)
+            else:
+                # Guess the const CDF Data Type
+                (guess_dims, guess_types, guess_elements) = self._types(var_data.data)
 
         # Check the Attributes that can be derived
-        if not var_name == "time":
-            measurement_attributes["DEPEND_0"] = self._get_depend()
-        measurement_attributes["DISPLAY_TYPE"] = self._get_display_type()
-        measurement_attributes["FIELDNAM"] = self._get_fieldnam(var_name)
-        measurement_attributes["FILLVAL"] = self._get_fillval(guess_types[0])
-        measurement_attributes["FORMAT"] = self._get_format(var_data, guess_types[0])
-        measurement_attributes["LABLAXIS"] = self._get_lablaxis(data, var_name)
-        measurement_attributes["SI_CONVERSION"] = self._get_si_conversion(
-            data, var_name
-        )
-        measurement_attributes["UNITS"] = self._get_units(data, var_name)
-        measurement_attributes["VALIDMIN"] = self._get_validmin(guess_types[0])
-        measurement_attributes["VALIDMAX"] = self._get_validmax(guess_types[0])
-        measurement_attributes["VAR_TYPE"] = self._get_var_type()
+        var_type = self._get_var_type(data, var_name)
+
+        if var_type == "data":
+            if not var_name == "time":
+                measurement_attributes["DEPEND_0"] = self._get_depend()
+            measurement_attributes["DISPLAY_TYPE"] = self._get_display_type()
+            measurement_attributes["FIELDNAM"] = self._get_fieldnam(var_name)
+            measurement_attributes["FILLVAL"] = self._get_fillval(guess_types[0])
+            measurement_attributes["FORMAT"] = self._get_format(
+                var_data, guess_types[0]
+            )
+            measurement_attributes["LABLAXIS"] = self._get_lablaxis(data, var_name)
+            measurement_attributes["SI_CONVERSION"] = self._get_si_conversion(
+                data, var_name
+            )
+            measurement_attributes["UNITS"] = self._get_units(data, var_name)
+            measurement_attributes["VALIDMIN"] = self._get_validmin(guess_types[0])
+            measurement_attributes["VALIDMAX"] = self._get_validmax(guess_types[0])
+            measurement_attributes["VAR_TYPE"] = self._get_var_type(data, var_name)
+        elif var_type == "support_data":
+            measurement_attributes["FIELDNAM"] = self._get_fieldnam(var_name)
+            measurement_attributes["FILLVAL"] = self._get_fillval(guess_types[0])
+            measurement_attributes["FORMAT"] = self._get_format(
+                var_data, guess_types[0]
+            )
+            measurement_attributes["LABLAXIS"] = self._get_lablaxis(data, var_name)
+            measurement_attributes["SI_CONVERSION"] = self._get_si_conversion(
+                data, var_name
+            )
+            measurement_attributes["UNITS"] = self._get_units(data, var_name)
+            measurement_attributes["VALIDMIN"] = self._get_validmin(guess_types[0])
+            measurement_attributes["VALIDMAX"] = self._get_validmax(guess_types[0])
+            measurement_attributes["VAR_TYPE"] = self._get_var_type(data, var_name)
+        elif var_type == "metadata":
+            measurement_attributes["FIELDNAM"] = self._get_fieldnam(var_name)
+            measurement_attributes["FILLVAL"] = self._get_fillval(guess_types[0])
+            measurement_attributes["FORMAT"] = self._get_format(
+                var_data, guess_types[0]
+            )
+            measurement_attributes["VAR_TYPE"] = self._get_var_type(data, var_name)
+        else:
+            warn_user(
+                f"Variable {var_name} has unrecognizable VAR_TYPE ({var_type}). Cannot Derive Metadata for Variable."
+            )
+
         return measurement_attributes
 
     def derive_time_attributes(self, data):
@@ -932,6 +967,8 @@ class HERMESDataSchema:
             const.CDF_CHAR.value,
             const.CDF_UCHAR.value,
         ):
+            if hasattr(var_data, "data"):
+                var_data = var_data.data
             fmt = "A{}".format(len(var_data))
         else:
             raise ValueError(
@@ -973,8 +1010,15 @@ class HERMESDataSchema:
             conversion_rate = u.ns.to(u.s)
             si_conversion = f"{conversion_rate:e}>{u.s}"
         else:
-            conversion_rate = var_data.unit.to(var_data.si.unit)
-            si_conversion = f"{conversion_rate:e}>{var_data.si.unit}"
+            # Get the Units as a String
+            if isinstance(var_data, u.Quantity):
+                try:
+                    conversion_rate = var_data.unit.to(var_data.si.unit)
+                    si_conversion = f"{conversion_rate:e}>{var_data.si.unit}"
+                except u.UnitConversionError:
+                    si_conversion = f"1.0>{var_data.unit}"
+            else:
+                si_conversion = " > "
         return si_conversion
 
     def _get_time_base(self, guess_type):
@@ -1000,8 +1044,11 @@ class HERMESDataSchema:
         var_data = data[var_name]
         unit = ""
         # Get the Unit from the TimeSeries Quantity if it exists
-        if hasattr(var_data, "unit"):
+        if hasattr(var_data, "unit") and var_data.unit is not None:
             unit = var_data.unit.to_string()
+        # Try to ge the UNITS from the metadata
+        elif "UNITS" in var_data.meta and var_data.meta["UNITS"] is not None:
+            unit = var_data.meta["UNITS"]
         return unit
 
     def _get_validmin(self, guess_type):
@@ -1026,8 +1073,15 @@ class HERMESDataSchema:
             minval, maxval = self._get_minmax(guess_type)
             return maxval
 
-    def _get_var_type(self):
-        return "data"
+    def _get_var_type(self, data, var_name):
+        # Get the Variable Data
+        var_data = data[var_name]
+        attr_name = "VAR_TYPE"
+        if (attr_name not in var_data.meta) or (not var_data.meta[attr_name]):
+            var_type = "data"
+        else:
+            var_type = var_data.meta[attr_name]
+        return var_type
 
     # =============================================================================================
     #                             GLOBAL METADATA DERIVATIONS

--- a/hermes_core/util/schema.py
+++ b/hermes_core/util/schema.py
@@ -19,29 +19,29 @@ from hermes_core import log
 from hermes_core.util import util, const
 from hermes_core.util.exceptions import warn_user
 
-__all__ = ["HERMESDataSchema"]
+__all__ = ["HermesDataSchema"]
 
 DEFAULT_GLOBAL_CDF_ATTRS_SCHEMA_FILE = "hermes_default_global_cdf_attrs_schema.yaml"
 DEFAULT_GLOBAL_CDF_ATTRS_FILE = "hermes_default_global_cdf_attrs.yaml"
 DEFAULT_VARIABLE_CDF_ATTRS_SCHEMA_FILE = "hermes_default_variable_cdf_attrs_schema.yaml"
 
 
-class HERMESDataSchema:
+class HermesDataSchema:
     """Class representing the schema of a file type."""
 
     def __init__(self):
         super().__init__()
 
         # Data Validation, Complaiance, Derived Attributes
-        self._global_attr_schema = HERMESDataSchema._load_default_global_attr_schema()
+        self._global_attr_schema = HermesDataSchema._load_default_global_attr_schema()
 
         # Data Validation and Compliance for Variable Data
         self._variable_attr_schema = (
-            HERMESDataSchema._load_default_variable_attr_schema()
+            HermesDataSchema._load_default_variable_attr_schema()
         )
 
         # Load Default Global Attributes
-        self._default_global_attributes = HERMESDataSchema._load_default_attributes()
+        self._default_global_attributes = HermesDataSchema._load_default_attributes()
 
         self.cdftypenames = {
             const.CDF_BYTE.value: "CDF_BYTE",
@@ -111,7 +111,7 @@ class HERMESDataSchema:
             / DEFAULT_GLOBAL_CDF_ATTRS_SCHEMA_FILE
         )
         # Load the Schema
-        return HERMESDataSchema._load_yaml_data(yaml_file_path=default_schema_path)
+        return HermesDataSchema._load_yaml_data(yaml_file_path=default_schema_path)
 
     @staticmethod
     def _load_default_variable_attr_schema() -> dict:
@@ -122,7 +122,7 @@ class HERMESDataSchema:
             / DEFAULT_VARIABLE_CDF_ATTRS_SCHEMA_FILE
         )
         # Load the Schema
-        return HERMESDataSchema._load_yaml_data(yaml_file_path=default_schema_path)
+        return HermesDataSchema._load_yaml_data(yaml_file_path=default_schema_path)
 
     @staticmethod
     def _load_default_attributes():
@@ -132,7 +132,7 @@ class HERMESDataSchema:
             / "data"
             / DEFAULT_GLOBAL_CDF_ATTRS_SCHEMA_FILE
         )
-        global_schema = HERMESDataSchema._load_yaml_data(
+        global_schema = HermesDataSchema._load_yaml_data(
             yaml_file_path=default_attributes_path
         )
         return {
@@ -175,8 +175,8 @@ class HERMESDataSchema:
             A template for required global attributes that must be provided.
         """
         template = OrderedDict()
-        global_attribute_schema = HERMESDataSchema._load_default_global_attr_schema()
-        default_global_attributes = HERMESDataSchema._load_default_attributes()
+        global_attribute_schema = HermesDataSchema._load_default_global_attr_schema()
+        default_global_attributes = HermesDataSchema._load_default_attributes()
         for attr_name, attr_schema in global_attribute_schema.items():
             if (
                 attr_schema["required"]
@@ -199,7 +199,7 @@ class HERMESDataSchema:
         """
         template = OrderedDict()
         measurement_attribute_schema = (
-            HERMESDataSchema._load_default_variable_attr_schema()
+            HermesDataSchema._load_default_variable_attr_schema()
         )
         for attr_name, attr_schema in measurement_attribute_schema[
             "attribute_key"
@@ -218,12 +218,12 @@ class HERMESDataSchema:
         - description: (`str`) A brief description of the attribute
         - default: (`str`) The default value used if none is provided
         - derived: (`bool`) Whether the attibute can be derived by the HERMES
-            :py:class:`~hermes_core.util.schema.HERMESDataSchema` class
+            :py:class:`~hermes_core.util.schema.HermesDataSchema` class
         - required: (`bool`) Whether the attribute is required by HERMES standards
         - validate: (`bool`) Whether the attribute is included in the
             :py:func:`~hermes_core.util.validation.validate` checks (Note, not all attributes that
             are required are validated)
-        - overwrite: (`bool`) Whether the :py:class:`~hermes_core.util.schema.HERMESDataSchema`
+        - overwrite: (`bool`) Whether the :py:class:`~hermes_core.util.schema.HermesDataSchema`
             attribute derivations will overwrite an existing attribute value with an updated
             attribute value from the derivation process.
 
@@ -241,7 +241,7 @@ class HERMESDataSchema:
         ------
         KeyError: If attribute_name is not a recognized global attribute.
         """
-        global_attribute_schema = HERMESDataSchema._load_default_global_attr_schema()
+        global_attribute_schema = HermesDataSchema._load_default_global_attr_schema()
 
         # Strip the Description of New Lines
         for attr_name in global_attribute_schema.keys():
@@ -276,9 +276,9 @@ class HERMESDataSchema:
 
         - description: (`str`) A brief description of the attribute
         - derived: (`bool`) Whether the attibute can be derived by the HERMES
-            :py:class:`~hermes_core.util.schema.HERMESDataSchema` class
+            :py:class:`~hermes_core.util.schema.HermesDataSchema` class
         - required: (`bool`) Whether the attribute is required by HERMES standards
-        - overwrite: (`bool`) Whether the :py:class:`~hermes_core.util.schema.HERMESDataSchema`
+        - overwrite: (`bool`) Whether the :py:class:`~hermes_core.util.schema.HermesDataSchema`
             attribute derivations will overwrite an existing attribute value with an updated
             attribute value from the derivation process.
         - valid_values: (`str`) List of allowed values the attribute can take for HERMES products,
@@ -304,7 +304,7 @@ class HERMESDataSchema:
         KeyError: If attribute_name is not a recognized global attribute.
         """
         measurement_attribute_schema = (
-            HERMESDataSchema._load_default_variable_attr_schema()
+            HermesDataSchema._load_default_variable_attr_schema()
         )
         measurement_attribute_key = measurement_attribute_schema["attribute_key"]
 
@@ -415,7 +415,7 @@ class HERMESDataSchema:
         @raise ValueError: if L{data} has irregular dimensions
 
         """
-        d = HERMESDataSchema._check_well_formed(data)
+        d = HermesDataSchema._check_well_formed(data)
         dims = d.shape
         elements = 1
         types = []

--- a/hermes_core/util/tests/test_io.py
+++ b/hermes_core/util/tests/test_io.py
@@ -1,0 +1,102 @@
+"""Tests for Loading and Saving data from data containers"""
+
+from collections import OrderedDict
+from pathlib import Path
+import pytest
+import json
+import numpy as np
+from numpy.random import random
+import tempfile
+from astropy.timeseries import TimeSeries
+from astropy.time import Time
+from astropy.units import Quantity
+from spacepy.pycdf import CDFError, CDF
+from hermes_core.timedata import TimeData
+
+
+def get_test_timedata():
+    ts = TimeSeries()
+    ts.meta.update(
+        {
+            "Descriptor": "EEA>Electron Electrostatic Analyzer",
+            "Data_level": "l1>Level 1",
+            "Data_version": "v0.0.1",
+            "MODS": [
+                "v0.0.0 - Original version.",
+                "v1.0.0 - Include trajectory vectors and optics state.",
+                "v1.1.0 - Update metadata: counts -> flux.",
+                "v1.2.0 - Added flux error.",
+                "v1.3.0 - Trajectory vector errors are now deltas.",
+            ],
+        }
+    )
+
+    # Create an astropy.Time object
+    time = np.arange(10)
+    time_col = Time(time, format="unix")
+    ts["time"] = time_col
+
+    # Add Measurement
+    quant = Quantity(value=random(size=(10)), unit="m", dtype=np.uint16)
+    ts["measurement"] = quant
+    ts["measurement"].meta = OrderedDict(
+        {
+            "VAR_TYPE": "data",
+            "CATDESC": "Test Data",
+        }
+    )
+    timedata = TimeData(data=ts)
+    return timedata
+
+
+def test_cdf_io():
+    """Test CDF IO Handler on Default Data"""
+    # Get Test Datas
+    td = get_test_timedata()
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Convert TimeData the to a CDF File
+        test_file_output_path = td.save(output_path=tmpdirname)
+
+        # Load the CDF to a TimeData Object
+        td_loaded = TimeData.load(test_file_output_path)
+
+        assert td.shape == td_loaded.shape
+
+        with pytest.raises(CDFError):
+            td_loaded.save(output_path=tmpdirname)
+
+
+def test_cdf_bad_file_path():
+    """Test Loading CDF from a non-existant file"""
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Try loading from non-existant_path
+        with pytest.raises(FileNotFoundError):
+            _ = TimeData.load(tmpdirname + "non_existant_file.cdf")
+
+
+def test_cdf_nrv_support_data():
+    """
+    Test Loading Non-Record-Varying data with CDF IO Handler
+    """
+    # Get Test Datas
+    td = get_test_timedata()
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Convert TimeData the to a CDF File
+        test_file_output_path = td.save(output_path=tmpdirname)
+
+        # Load the JSON file as JSON
+        with CDF(test_file_output_path, readonly=False) as cdf_file:
+            # Add Non-Record-Varying Variable
+            cdf_file["Test_NRV_Var"] = [1, 2, 3]
+
+            # Add Support Data Variable
+            cdf_file["Test_Support_Var"] = np.arange(10)
+            cdf_file["Test_Support_Var"].meta["UNITS"] = "counts"
+
+        # Make sure we can load the modified JSON
+        td_loaded = TimeData.load(test_file_output_path)
+
+        assert "Test_NRV_Var" in td_loaded.support
+        assert "Test_Support_Var" in td_loaded.columns

--- a/hermes_core/util/tests/test_io.py
+++ b/hermes_core/util/tests/test_io.py
@@ -45,7 +45,7 @@ def get_test_hermes_data():
             "CATDESC": "Test Data",
         }
     )
-    hermes_data = HermesData(data=ts)
+    hermes_data = HermesData(timeseries=ts)
     return hermes_data
 
 

--- a/hermes_core/util/tests/test_io.py
+++ b/hermes_core/util/tests/test_io.py
@@ -61,7 +61,8 @@ def test_cdf_io():
         # Load the CDF to a HermesData Object
         td_loaded = HermesData.load(test_file_output_path)
 
-        assert td.shape == td_loaded.shape
+        assert len(td.timeseries) == len(td_loaded.timeseries)
+        assert len(td.timeseries.columns) == len(td_loaded.timeseries.columns)
 
         with pytest.raises(CDFError):
             td_loaded.save(output_path=tmpdirname)
@@ -99,4 +100,4 @@ def test_cdf_nrv_support_data():
         td_loaded = HermesData.load(test_file_output_path)
 
         assert "Test_NRV_Var" in td_loaded.support
-        assert "Test_Support_Var" in td_loaded.columns
+        assert "Test_Support_Var" in td_loaded.timeseries.columns

--- a/hermes_core/util/tests/test_io.py
+++ b/hermes_core/util/tests/test_io.py
@@ -11,10 +11,10 @@ from astropy.timeseries import TimeSeries
 from astropy.time import Time
 from astropy.units import Quantity
 from spacepy.pycdf import CDFError, CDF
-from hermes_core.timedata import TimeData
+from hermes_core.timedata import HermesData
 
 
-def get_test_timedata():
+def get_test_hermes_data():
     ts = TimeSeries()
     ts.meta.update(
         {
@@ -45,21 +45,21 @@ def get_test_timedata():
             "CATDESC": "Test Data",
         }
     )
-    timedata = TimeData(data=ts)
-    return timedata
+    hermes_data = HermesData(data=ts)
+    return hermes_data
 
 
 def test_cdf_io():
     """Test CDF IO Handler on Default Data"""
     # Get Test Datas
-    td = get_test_timedata()
+    td = get_test_hermes_data()
 
     with tempfile.TemporaryDirectory() as tmpdirname:
-        # Convert TimeData the to a CDF File
+        # Convert HermesData the to a CDF File
         test_file_output_path = td.save(output_path=tmpdirname)
 
-        # Load the CDF to a TimeData Object
-        td_loaded = TimeData.load(test_file_output_path)
+        # Load the CDF to a HermesData Object
+        td_loaded = HermesData.load(test_file_output_path)
 
         assert td.shape == td_loaded.shape
 
@@ -72,7 +72,7 @@ def test_cdf_bad_file_path():
     with tempfile.TemporaryDirectory() as tmpdirname:
         # Try loading from non-existant_path
         with pytest.raises(FileNotFoundError):
-            _ = TimeData.load(tmpdirname + "non_existant_file.cdf")
+            _ = HermesData.load(tmpdirname + "non_existant_file.cdf")
 
 
 def test_cdf_nrv_support_data():
@@ -80,10 +80,10 @@ def test_cdf_nrv_support_data():
     Test Loading Non-Record-Varying data with CDF IO Handler
     """
     # Get Test Datas
-    td = get_test_timedata()
+    td = get_test_hermes_data()
 
     with tempfile.TemporaryDirectory() as tmpdirname:
-        # Convert TimeData the to a CDF File
+        # Convert HermesData the to a CDF File
         test_file_output_path = td.save(output_path=tmpdirname)
 
         # Load the JSON file as JSON
@@ -96,7 +96,7 @@ def test_cdf_nrv_support_data():
             cdf_file["Test_Support_Var"].meta["UNITS"] = "counts"
 
         # Make sure we can load the modified JSON
-        td_loaded = TimeData.load(test_file_output_path)
+        td_loaded = HermesData.load(test_file_output_path)
 
         assert "Test_NRV_Var" in td_loaded.support
         assert "Test_Support_Var" in td_loaded.columns

--- a/hermes_core/util/tests/test_schema.py
+++ b/hermes_core/util/tests/test_schema.py
@@ -84,7 +84,9 @@ def test_hermes_data_schema():
     # Measurement Attribute Info
     assert schema.measurement_attribute_info() is not None
     assert isinstance(schema.measurement_attribute_info(), Table)
-    assert isinstance(schema.measurement_attribute_info(attribute_name="CATDESC"), Table)
+    assert isinstance(
+        schema.measurement_attribute_info(attribute_name="CATDESC"), Table
+    )
     with pytest.raises(KeyError):
         _ = schema.measurement_attribute_info(attribute_name="NotAnAttribute")
 
@@ -387,7 +389,9 @@ def test_si_conversion():
     # Dimensionless Units
     test_data.add_measurement(
         measure_name="measurement1",
-        data=u.Quantity(value=random(size=(10)), unit=u.dimensionless_unscaled, dtype=np.uint16),
+        data=u.Quantity(
+            value=random(size=(10)), unit=u.dimensionless_unscaled, dtype=np.uint16
+        ),
     )
     assert HermesDataSchema()._get_units(test_data.timeseries, "measurement1") == ""
     assert (
@@ -401,7 +405,10 @@ def test_si_conversion():
         data=u.Quantity(value=random(size=(10)), unit=u.ct, dtype=np.uint16),
     )
     assert HermesDataSchema()._get_units(test_data.timeseries, "measurement2") == "ct"
-    assert HermesDataSchema()._get_si_conversion(test_data.timeseries, "measurement2") == "1.0>ct"
+    assert (
+        HermesDataSchema()._get_si_conversion(test_data.timeseries, "measurement2")
+        == "1.0>ct"
+    )
 
 
 def test_resolution():
@@ -451,7 +458,8 @@ def test_time_base():
 def test_time_scale():
     """Function to test time scale"""
     assert (
-        HermesDataSchema()._get_time_scale(const.CDF_TIME_TT2000.value) == "Terrestrial Time (TT)"
+        HermesDataSchema()._get_time_scale(const.CDF_TIME_TT2000.value)
+        == "Terrestrial Time (TT)"
     )
 
     with pytest.raises(TypeError):

--- a/hermes_core/util/tests/test_schema.py
+++ b/hermes_core/util/tests/test_schema.py
@@ -10,12 +10,12 @@ from astropy.timeseries import TimeSeries
 from astropy.table import Table
 import astropy.units as u
 from spacepy.pycdf import CDF
-from hermes_core.timedata import TimeData
+from hermes_core.timedata import HermesData
 from hermes_core.util.schema import HERMESDataSchema
 from hermes_core.util import const
 
 
-def get_test_timedata():
+def get_test_hermes_data():
     ts = TimeSeries()
     ts.meta.update(
         {
@@ -46,8 +46,8 @@ def get_test_timedata():
             "CATDESC": "Test Data",
         }
     )
-    timedata = TimeData(data=ts)
-    return timedata
+    hermes_data = HermesData(data=ts)
+    return hermes_data
 
 
 def test_hermes_data_schema():
@@ -125,10 +125,10 @@ def test_global_attributes():
             "CATDESC": "Test Data",
         }
     )
-    template = TimeData.global_attribute_template("eea", "l2", "0.0.0")
+    template = HermesData.global_attribute_template("eea", "l2", "0.0.0")
 
-    # Create TimeData
-    td = TimeData(data=ts, meta=template)
+    # Create HermesData
+    td = HermesData(data=ts, meta=template)
     with pytest.raises(ValueError):
         _ = HERMESDataSchema()._derive_global_attribute(td, "bad_attribute")
 
@@ -385,8 +385,8 @@ def test_format():
 
 def test_si_conversion():
     """Test the SI Units Conversion"""
-    # Get Test TimeData
-    test_data = get_test_timedata()
+    # Get Test HermesData
+    test_data = get_test_hermes_data()
     # Default in Test Data "m"
     assert (
         HERMESDataSchema()._get_si_conversion(test_data, "measurement")
@@ -433,11 +433,11 @@ def test_resolution():
             "CATDESC": "Test Data",
         }
     )
-    template = TimeData.global_attribute_template("eea", "l2", "0.0.0")
+    template = HermesData.global_attribute_template("eea", "l2", "0.0.0")
 
     # Get Resolution
     with pytest.raises(ValueError):
-        td = TimeData(data=ts, meta=template)
+        td = HermesData(data=ts, meta=template)
 
 
 def test_reference_position():

--- a/hermes_core/util/tests/test_schema.py
+++ b/hermes_core/util/tests/test_schema.py
@@ -11,7 +11,7 @@ from astropy.table import Table
 import astropy.units as u
 from spacepy.pycdf import CDF
 from hermes_core.timedata import HermesData
-from hermes_core.util.schema import HERMESDataSchema
+from hermes_core.util.schema import HermesDataSchema
 from hermes_core.util import const
 
 
@@ -52,7 +52,7 @@ def get_test_hermes_data():
 
 def test_hermes_data_schema():
     """Test Schema Template and Info Functions"""
-    schema = HERMESDataSchema()
+    schema = HermesDataSchema()
 
     # Global Attribute Schema
     assert schema.global_attribute_schema is not None
@@ -104,7 +104,7 @@ def test_load_yaml_data():
             file.write(invalid_yaml)
 
         # Load from an non-existant file
-        yaml_data = HERMESDataSchema._load_yaml_data(tmpdirname + "test.yaml")
+        yaml_data = HermesDataSchema._load_yaml_data(tmpdirname + "test.yaml")
         assert yaml_data == {}
 
 
@@ -130,7 +130,7 @@ def test_global_attributes():
     # Create HermesData
     td = HermesData(data=ts, meta=template)
     with pytest.raises(ValueError):
-        _ = HERMESDataSchema()._derive_global_attribute(td, "bad_attribute")
+        _ = HermesDataSchema()._derive_global_attribute(td, "bad_attribute")
 
 
 def test_check_well_formed():
@@ -139,32 +139,25 @@ def test_check_well_formed():
     # Badly Shaped Data
     data = [np.array([1, 2, 3]), np.array([[4, 5], [6, 7]])]
     with pytest.raises(ValueError):
-        _ = HERMESDataSchema._check_well_formed(data)
+        _ = HermesDataSchema._check_well_formed(data)
 
     # Empty Data
     data = np.array([], dtype=object)
-    d = HERMESDataSchema._check_well_formed(data)
+    d = HermesDataSchema._check_well_formed(data)
     assert len(d) == 0
 
     # Badly Shaped Object
     data = np.array([np.array([1, 2, 3]), np.array([[4, 5], [6, 7]])], dtype=object)
     with pytest.raises(ValueError):
-        _ = HERMESDataSchema._check_well_formed(data)
+        _ = HermesDataSchema._check_well_formed(data)
 
 
 def test_types():
     """Function to test getting the CDF data types for different data types"""
 
     # String Type
-    _, types, _ = HERMESDataSchema()._types("")
+    _, types, _ = HermesDataSchema()._types("")
     assert types == [51, 52]
-
-    # Time Types
-    # data = np.array(
-    #     ["2023-08-03T10:20:30.123456789", "2023-08-03T15:30:45.678901234"], dtype="datetime64[ns]"
-    # )
-    # _, types, _ = HERMESDataSchema()._types(data)
-    # assert types == [const.CDF_TIME_TT2000, const.CDF_EPOCH16, const.CDF_EPOCH]
 
 
 def test_type_guessing():
@@ -291,27 +284,27 @@ def test_type_guessing():
         ((1,), [const.CDF_CHAR, const.CDF_UCHAR], 8),
     ]
     with pytest.raises(ValueError):
-        HERMESDataSchema()._types([object()])
+        HermesDataSchema()._types([object()])
     for s, t in zip(samples, types):
         t = (t[0], [i.value for i in t[1]], t[2])
-        assert t == HERMESDataSchema()._types(s)
+        assert t == HermesDataSchema()._types(s)
 
 
 def test_min_max_none():
     """Get min/max values for None types"""
     with pytest.raises(ValueError):
-        HERMESDataSchema()._get_minmax(None)
+        HermesDataSchema()._get_minmax(None)
 
 
 def test_min_max_unknown():
     """Get min/max values for unknown types"""
     with pytest.raises(ValueError):
-        HERMESDataSchema()._get_minmax("unknown_type")
+        HermesDataSchema()._get_minmax("unknown_type")
 
 
 def test_min_max_TT2000():
     """Get min/max values for TT2000 types"""
-    minval, maxval = HERMESDataSchema()._get_minmax(const.CDF_TIME_TT2000)
+    minval, maxval = HermesDataSchema()._get_minmax(const.CDF_TIME_TT2000)
     # Make sure the minimum isn't just plain invalid
     assert minval == datetime.datetime(1, 1, 1)
     assert maxval == datetime.datetime(2292, 4, 11, 11, 46, 7, 670776)
@@ -319,7 +312,7 @@ def test_min_max_TT2000():
 
 def test_min_max_Epoch16():
     """Get min/max values for Epoch16 types"""
-    minval, maxval = HERMESDataSchema()._get_minmax(const.CDF_EPOCH16)
+    minval, maxval = HermesDataSchema()._get_minmax(const.CDF_EPOCH16)
     # Make sure the minimum isn't just plain invalid
     assert minval == datetime.datetime(1, 1, 1)
     assert maxval == datetime.datetime(9999, 12, 31, 23, 59, 59)
@@ -327,7 +320,7 @@ def test_min_max_Epoch16():
 
 def test_min_max_Epoch():
     """Get min/max values for EPOCH types"""
-    minval, maxval = HERMESDataSchema()._get_minmax(const.CDF_EPOCH)
+    minval, maxval = HermesDataSchema()._get_minmax(const.CDF_EPOCH)
     # Make sure the minimum isn't just plain invalid
     assert minval == datetime.datetime(1, 1, 1)
     assert maxval == datetime.datetime(9999, 12, 31, 23, 59, 59)
@@ -335,14 +328,14 @@ def test_min_max_Epoch():
 
 def test_min_max_Float():
     """Get min/max values for a float"""
-    minval, maxval = HERMESDataSchema()._get_minmax(const.CDF_FLOAT)
+    minval, maxval = HermesDataSchema()._get_minmax(const.CDF_FLOAT)
     np.allclose(-3.4028234663853e38, minval)
     np.allclose(3.4028234663853e38, maxval)
 
 
 def test_min_max_Int():
     """Get min/max values for an integer"""
-    minval, maxval = HERMESDataSchema()._get_minmax(const.CDF_INT1)
+    minval, maxval = HermesDataSchema()._get_minmax(const.CDF_INT1)
     assert -128 == minval
     assert 127 == maxval
 
@@ -373,13 +366,13 @@ def test_format():
                 v.attrs["VALIDMIN"] = vmin
             if vmin is not None:
                 v.attrs["VALIDMAX"] = vmax
-            format = HERMESDataSchema()._get_format(cdf["var"], t)
+            format = HermesDataSchema()._get_format(cdf["var"], t)
             assert e == format
             del cdf["var"]
 
         # Test Format Char
         v = cdf.new("var", data=["hi", "there"])
-        format = HERMESDataSchema()._get_format(cdf["var"], const.CDF_CHAR.value)
+        format = HermesDataSchema()._get_format(cdf["var"], const.CDF_CHAR.value)
         assert "A2" == format
 
 
@@ -389,7 +382,7 @@ def test_si_conversion():
     test_data = get_test_hermes_data()
     # Default in Test Data "m"
     assert (
-        HERMESDataSchema()._get_si_conversion(test_data, "measurement")
+        HermesDataSchema()._get_si_conversion(test_data, "measurement")
         == "1.000000e+00>m"
     )
 
@@ -400,9 +393,9 @@ def test_si_conversion():
             value=random(size=(10)), unit=u.dimensionless_unscaled, dtype=np.uint16
         ),
     )
-    assert HERMESDataSchema()._get_units(test_data, "measurement1") == ""
+    assert HermesDataSchema()._get_units(test_data, "measurement1") == ""
     assert (
-        HERMESDataSchema()._get_si_conversion(test_data, "measurement1")
+        HermesDataSchema()._get_si_conversion(test_data, "measurement1")
         == "1.000000e+00>"
     )
 
@@ -411,8 +404,8 @@ def test_si_conversion():
         measure_name="measurement2",
         data=u.Quantity(value=random(size=(10)), unit=u.ct, dtype=np.uint16),
     )
-    assert HERMESDataSchema()._get_units(test_data, "measurement2") == "ct"
-    assert HERMESDataSchema()._get_si_conversion(test_data, "measurement2") == "1.0>ct"
+    assert HermesDataSchema()._get_units(test_data, "measurement2") == "ct"
+    assert HermesDataSchema()._get_si_conversion(test_data, "measurement2") == "1.0>ct"
 
 
 def test_resolution():
@@ -443,36 +436,36 @@ def test_resolution():
 def test_reference_position():
     """Function to test time reference position"""
     assert (
-        HERMESDataSchema()._get_reference_position(const.CDF_TIME_TT2000.value)
+        HermesDataSchema()._get_reference_position(const.CDF_TIME_TT2000.value)
         == "rotating Earth geoid"
     )
 
     with pytest.raises(TypeError):
-        HERMESDataSchema()._get_reference_position(const.CDF_EPOCH.value)
+        HermesDataSchema()._get_reference_position(const.CDF_EPOCH.value)
 
 
 def test_time_base():
     """Function to test time base"""
-    assert HERMESDataSchema()._get_time_base(const.CDF_TIME_TT2000.value) == "J2000"
+    assert HermesDataSchema()._get_time_base(const.CDF_TIME_TT2000.value) == "J2000"
 
     with pytest.raises(TypeError):
-        HERMESDataSchema()._get_time_base(const.CDF_EPOCH.value)
+        HermesDataSchema()._get_time_base(const.CDF_EPOCH.value)
 
 
 def test_time_scale():
     """Function to test time scale"""
     assert (
-        HERMESDataSchema()._get_time_scale(const.CDF_TIME_TT2000.value)
+        HermesDataSchema()._get_time_scale(const.CDF_TIME_TT2000.value)
         == "Terrestrial Time (TT)"
     )
 
     with pytest.raises(TypeError):
-        HERMESDataSchema()._get_time_scale(const.CDF_EPOCH.value)
+        HermesDataSchema()._get_time_scale(const.CDF_EPOCH.value)
 
 
 def test_time_units():
     """Function to test time units"""
-    assert HERMESDataSchema()._get_time_units(const.CDF_TIME_TT2000.value) == "ns"
+    assert HermesDataSchema()._get_time_units(const.CDF_TIME_TT2000.value) == "ns"
 
     with pytest.raises(TypeError):
-        HERMESDataSchema()._get_time_units(const.CDF_EPOCH.value)
+        HermesDataSchema()._get_time_units(const.CDF_EPOCH.value)

--- a/hermes_core/util/tests/test_schema.py
+++ b/hermes_core/util/tests/test_schema.py
@@ -382,7 +382,7 @@ def test_si_conversion():
     test_data = get_test_hermes_data()
     # Default in Test Data "m"
     assert (
-        HermesDataSchema()._get_si_conversion(test_data, "measurement")
+        HermesDataSchema()._get_si_conversion(test_data.timeseries, "measurement")
         == "1.000000e+00>m"
     )
 
@@ -393,9 +393,9 @@ def test_si_conversion():
             value=random(size=(10)), unit=u.dimensionless_unscaled, dtype=np.uint16
         ),
     )
-    assert HermesDataSchema()._get_units(test_data, "measurement1") == ""
+    assert HermesDataSchema()._get_units(test_data.timeseries, "measurement1") == ""
     assert (
-        HermesDataSchema()._get_si_conversion(test_data, "measurement1")
+        HermesDataSchema()._get_si_conversion(test_data.timeseries, "measurement1")
         == "1.000000e+00>"
     )
 
@@ -404,8 +404,11 @@ def test_si_conversion():
         measure_name="measurement2",
         data=u.Quantity(value=random(size=(10)), unit=u.ct, dtype=np.uint16),
     )
-    assert HermesDataSchema()._get_units(test_data, "measurement2") == "ct"
-    assert HermesDataSchema()._get_si_conversion(test_data, "measurement2") == "1.0>ct"
+    assert HermesDataSchema()._get_units(test_data.timeseries, "measurement2") == "ct"
+    assert (
+        HermesDataSchema()._get_si_conversion(test_data.timeseries, "measurement2")
+        == "1.0>ct"
+    )
 
 
 def test_resolution():

--- a/hermes_core/util/tests/test_schema.py
+++ b/hermes_core/util/tests/test_schema.py
@@ -46,7 +46,7 @@ def get_test_hermes_data():
             "CATDESC": "Test Data",
         }
     )
-    hermes_data = HermesData(data=ts)
+    hermes_data = HermesData(timeseries=ts)
     return hermes_data
 
 
@@ -128,7 +128,7 @@ def test_global_attributes():
     template = HermesData.global_attribute_template("eea", "l2", "0.0.0")
 
     # Create HermesData
-    td = HermesData(data=ts, meta=template)
+    td = HermesData(timeseries=ts, meta=template)
     with pytest.raises(ValueError):
         _ = HermesDataSchema()._derive_global_attribute(td, "bad_attribute")
 
@@ -430,7 +430,7 @@ def test_resolution():
 
     # Get Resolution
     with pytest.raises(ValueError):
-        td = HermesData(data=ts, meta=template)
+        td = HermesData(timeseries=ts, meta=template)
 
 
 def test_reference_position():

--- a/hermes_core/util/tests/test_validation.py
+++ b/hermes_core/util/tests/test_validation.py
@@ -10,7 +10,7 @@ import astropy.units as u
 from spacepy.pycdf import CDF
 import hermes_core
 from hermes_core.timedata import HermesData
-from hermes_core.util.schema import HERMESDataSchema
+from hermes_core.util.schema import HermesDataSchema
 from hermes_core.util.validation import validate
 
 SAMPLE_CDF_FILE = "hermes_nms_default_l1_20160322_123031_v0.0.1.cdf"

--- a/hermes_core/util/tests/test_validation.py
+++ b/hermes_core/util/tests/test_validation.py
@@ -59,7 +59,7 @@ def test_missing_global_attrs():
     # Create a Test HermesData
     ts = get_test_timeseries()
     template = HermesData.global_attribute_template("eea", "l2", "0.0.0")
-    td = HermesData(data=ts, meta=template)
+    td = HermesData(timeseries=ts, meta=template)
 
     # Convert to a CDF File and Validate
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -83,7 +83,7 @@ def test_missing_var_type():
     # Create a Test HermesData
     ts = get_test_timeseries()
     template = HermesData.global_attribute_template("eea", "l2", "0.0.0")
-    td = HermesData(data=ts, meta=template)
+    td = HermesData(timeseries=ts, meta=template)
 
     # Convert to a CDF File and Validate
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -106,7 +106,7 @@ def test_missing_variable_attrs():
     # Create a Test HermesData
     ts = get_test_timeseries()
     template = HermesData.global_attribute_template("eea", "l2", "0.0.0")
-    td = HermesData(data=ts, meta=template)
+    td = HermesData(timeseries=ts, meta=template)
 
     # Convert to a CDF File and Validate
     with tempfile.TemporaryDirectory() as tmpdirname:

--- a/hermes_core/util/tests/test_validation.py
+++ b/hermes_core/util/tests/test_validation.py
@@ -9,7 +9,7 @@ from astropy.timeseries import TimeSeries
 import astropy.units as u
 from spacepy.pycdf import CDF
 import hermes_core
-from hermes_core.timedata import TimeData
+from hermes_core.timedata import HermesData
 from hermes_core.util.schema import HERMESDataSchema
 from hermes_core.util.validation import validate
 
@@ -56,10 +56,10 @@ def test_non_existant_file():
 def test_missing_global_attrs():
     """Function to ensure missing global attributes are reported in validation"""
 
-    # Create a Test TimeData
+    # Create a Test HermesData
     ts = get_test_timeseries()
-    template = TimeData.global_attribute_template("eea", "l2", "0.0.0")
-    td = TimeData(data=ts, meta=template)
+    template = HermesData.global_attribute_template("eea", "l2", "0.0.0")
+    td = HermesData(data=ts, meta=template)
 
     # Convert to a CDF File and Validate
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -80,10 +80,10 @@ def test_missing_global_attrs():
 def test_missing_var_type():
     """Function to ensure missing variable attributes are reported in validation"""
 
-    # Create a Test TimeData
+    # Create a Test HermesData
     ts = get_test_timeseries()
-    template = TimeData.global_attribute_template("eea", "l2", "0.0.0")
-    td = TimeData(data=ts, meta=template)
+    template = HermesData.global_attribute_template("eea", "l2", "0.0.0")
+    td = HermesData(data=ts, meta=template)
 
     # Convert to a CDF File and Validate
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -103,10 +103,10 @@ def test_missing_var_type():
 def test_missing_variable_attrs():
     """Function to ensure missing variable attributes are reported in validation"""
 
-    # Create a Test TimeData
+    # Create a Test HermesData
     ts = get_test_timeseries()
-    template = TimeData.global_attribute_template("eea", "l2", "0.0.0")
-    td = TimeData(data=ts, meta=template)
+    template = HermesData.global_attribute_template("eea", "l2", "0.0.0")
+    td = HermesData(data=ts, meta=template)
 
     # Convert to a CDF File and Validate
     with tempfile.TemporaryDirectory() as tmpdirname:

--- a/hermes_core/util/validation.py
+++ b/hermes_core/util/validation.py
@@ -34,7 +34,7 @@ def validate(filepath):
     return validator.validate(filepath)
 
 
-class TimeDataValidator(ABC):
+class HermesDataValidator(ABC):
     """
     Abstract base class for heliophysics data validators.
     """
@@ -57,7 +57,7 @@ class TimeDataValidator(ABC):
         pass
 
 
-class CDFValidator(TimeDataValidator):
+class CDFValidator(HermesDataValidator):
     """
     Validator for CDF files.
     """

--- a/hermes_core/util/validation.py
+++ b/hermes_core/util/validation.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from abc import ABC, abstractmethod
 from spacepy.pycdf import CDF, CDFError
 from spacepy.pycdf.istp import FileChecks, VariableChecks
-from hermes_core.util.schema import HERMESDataSchema
+from hermes_core.util.schema import HermesDataSchema
 
 __all__ = ["validate", "CDFValidator"]
 
@@ -66,7 +66,7 @@ class CDFValidator(HermesDataValidator):
         super().__init__()
 
         # CDF Schema
-        self.schema = HERMESDataSchema()
+        self.schema = HermesDataSchema()
 
     def validate(self, file_path):
         """


### PR DESCRIPTION
This PR renames the `TimeData` class to the `HermesData` class following discussion with @ehsteve and implements suggested changes in #88. 
- Renames `TimeData` to `HermesData`
- Renames `HermesData.data` member to `HermesData.timeseries`
- Removes `HermesData` built-in function overrides that only applied to TimeSeries. 
- Renames `HERMESDataSchema` to `HermesDataSchema`
- Renames `TimeDataIOHandler` to `HermesDataIOHandler`

closes #88