### PR TITLE
Update Minimum Required Python Version to 3.9

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -27,6 +27,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        # Install spacepy without build isolation to avoid issues with numpy
+        pip install numpy
+        pip install spacepy --no-build-isolation
         python -m pip install -e '.[style]'
     - name: Lint with Black
       run: |

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        pip install pip setuptools wheel --upgrade
         # Install spacepy without build isolation to avoid issues with numpy
         pip install numpy
         pip install spacepy --no-build-isolation

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
+        python-version: [3.9, '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.9"
   jobs:
     pre_build:
       - wget https://sdc-aws-support.s3.amazonaws.com/cdf-binaries/latest.zip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,6 +16,7 @@ build:
       - pip install pip setuptools wheel --upgrade
       - pip install numpy
       - pip install spacepy --no-build-isolation
+      - pip install -e .[docs,all]
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
@@ -25,10 +26,10 @@ formats:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
-        - all
+# python:
+#   install:
+#     - method: pip
+#       path: .
+#       extra_requirements:
+#         - docs
+#         - all

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,6 +13,10 @@ build:
     pre_build:
       - wget https://sdc-aws-support.s3.amazonaws.com/cdf-binaries/latest.zip
       - unzip latest.zip
+      - pip install pip setuptools wheel --upgrade
+      - pip install numpy
+      - pip install spacepy --no-build-isolation
+      - pip install -e .[docs,all]
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
@@ -22,10 +26,10 @@ formats:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
-        - all
+# python:
+#   install:
+#     - method: pip
+#       path: .
+#       extra_requirements:
+#         - docs
+#         - all

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,7 +16,6 @@ build:
       - pip install pip setuptools wheel --upgrade
       - pip install numpy
       - pip install spacepy --no-build-isolation
-      - pip install -e .[docs,all]
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
@@ -26,10 +25,10 @@ formats:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#   install:
-#     - method: pip
-#       path: .
-#       extra_requirements:
-#         - docs
-#         - all
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+        - all

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [{name = "Steven Christe", email="steven.d.christe@nasa.gov"},
            {name = "Damian Barrous Dumme", email="damianbarrous@gmail.com"},
            {name = "Andrew Robbertz", email="a.robbertz@gmail.com"}]
 license = {file = "LICENSE.rst"}
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 keywords = ["hermes", "nasa mission", "space weather"]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -21,17 +21,15 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Physics",
 ]
 dependencies = [
-  'astropy>=4.1.0',
-  'numpy>=1.16.0',
-  'sunpy>=3.1.4',
+  'astropy>=5.3.3',
+  'numpy>=1.21.0',
+  'sunpy>=5.0.1',
   'spacepy>=0.4.1',
   'pyyaml>=5.3.1',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dependencies = [
   'astropy>=5.3.3',
-  'numpy>=1.21.0',
+  'numpy>=1.18.0',
   'sunpy>=5.0.1',
   'spacepy>=0.4.1',
   'pyyaml>=5.3.1',


### PR DESCRIPTION
This PR updates the minimum required version of Python to 3.9 that is supported for the HERMES Core Package. It also updates the CI Pipelines to this version from older versions, and removes testing support for older versions of Python. 