### PR TITLE
Update Default Attributes, Overwrite Policy, and Attribute Validation

### DIFF
--- a/hermes_core/data/hermes_default_variable_cdf_attrs_schema.yaml
+++ b/hermes_core/data/hermes_default_variable_cdf_attrs_schema.yaml
@@ -179,7 +179,7 @@ attribute_key:
       ISTP standard fill values are listed in Table 5-4.
     derived: true
     required: true
-    overwrite: true
+    overwrite: false
     valid_values: null
     alternate: null
   FORMAT:           # NOTE Only one of FORMAT or FORM_PTR should be present
@@ -190,7 +190,7 @@ attribute_key:
       where 3 of those characters are to the right of the decimal.
     derived: true
     required: true
-    overwrite: true
+    overwrite: false
     valid_values: null
     alternate: FORM_PTR
   FORM_PTR:
@@ -272,7 +272,7 @@ attribute_key:
       value must match the data type of the variable.
     derived: true
     required: true
-    overwrite: true
+    overwrite: false
     valid_values: null
     alternate: null
   VALIDMAX:
@@ -282,7 +282,7 @@ attribute_key:
       value must match the data type of the variable.
     derived: true
     required: true
-    overwrite: true
+    overwrite: false
     valid_values: null
     alternate: null
   VAR_TYPE:

--- a/hermes_core/data/hermes_default_variable_cdf_attrs_schema.yaml
+++ b/hermes_core/data/hermes_default_variable_cdf_attrs_schema.yaml
@@ -187,7 +187,9 @@ attribute_key:
       This field allows software to properly format the associated data when displayed on a
       screen or output to a file. Format can be specified using either Fortran or C format codes.
       For instance, "F10.3" indicates that the data should be displayed across 10 characters
-      where 3 of those characters are to the right of the decimal.
+      where 3 of those characters are to the right of the decimal. For a description of FORTRAN 
+      formatting codes see the docs here: 
+      https://docs.oracle.com/cd/E19957-01/805-4939/z40007437a2e/index.html
     derived: true
     required: true
     overwrite: false

--- a/hermes_core/util/schema.py
+++ b/hermes_core/util/schema.py
@@ -845,6 +845,13 @@ class HermesDataSchema:
         return value
 
     def _get_format(self, var_data, cdftype):
+        """
+        Format can be specified using either Fortran or C format codes.
+        For instance, "F10.3" indicates that the data should be displayed across 10 characters
+        where 3 of those characters are to the right of the decimal. For a description of FORTRAN
+        formatting codes see the docs here:
+        https://docs.oracle.com/cd/E19957-01/805-4939/z40007437a2e/index.html
+        """
         minn = "VALIDMIN"
         maxx = "VALIDMAX"
 

--- a/hermes_core/util/schema.py
+++ b/hermes_core/util/schema.py
@@ -962,7 +962,7 @@ class HermesDataSchema:
             else:
                 # No range, must not be populated, copied from REAL4/8(s) above
                 # OR we don't care because it's a 'big' number:
-                fmt = "G10.2E3"
+                fmt = "G10.8E3"
         elif cdftype in (
             const.CDF_CHAR.value,
             const.CDF_UCHAR.value,

--- a/hermes_core/util/schema.py
+++ b/hermes_core/util/schema.py
@@ -610,21 +610,14 @@ class HermesDataSchema:
         """
         if hasattr(cdftype, "value"):
             cdftype = cdftype.value
-        if cdftype == const.CDF_EPOCH.value:
+        if cdftype in [
+            const.CDF_EPOCH.value,
+            const.CDF_EPOCH16.value,
+            const.CDF_TIME_TT2000.value,
+        ]:
             return (
-                datetime.datetime(1, 1, 1),
-                # Can get asymptotically closer, but why bother
-                datetime.datetime(9999, 12, 31, 23, 59, 59),
-            )
-        elif cdftype == const.CDF_EPOCH16.value:
-            return (
-                datetime.datetime(1, 1, 1),
-                datetime.datetime(9999, 12, 31, 23, 59, 59),
-            )
-        elif cdftype == const.CDF_TIME_TT2000.value:
-            return (
-                datetime.datetime(1, 1, 1),
-                datetime.datetime(2292, 4, 11, 11, 46, 7, 670776),
+                datetime.datetime(1900, 1, 1, 0, 0, 0, 0),
+                datetime.datetime(2250, 1, 1, 0, 0, 0, 0),
             )
         dtype = self.numpytypedict.get(cdftype, None)
         if dtype is None:

--- a/hermes_core/util/tests/test_schema.py
+++ b/hermes_core/util/tests/test_schema.py
@@ -341,7 +341,14 @@ def test_min_max_Int():
 
 
 def test_format():
-    """Set the format"""
+    """
+    Set the format
+    Format can be specified using either Fortran or C format codes.
+    For instance, "F10.3" indicates that the data should be displayed across 10 characters
+    where 3 of those characters are to the right of the decimal. For a description of FORTRAN
+    formatting codes see the docs here:
+    https://docs.oracle.com/cd/E19957-01/805-4939/z40007437a2e/index.html
+    """
     # This is done by: type, expected, validmin, validmax (None okay)
     expected = (
         (const.CDF_EPOCH.value, "A24", None, None),

--- a/hermes_core/util/tests/test_schema.py
+++ b/hermes_core/util/tests/test_schema.py
@@ -354,7 +354,7 @@ def test_format():
         (const.CDF_FLOAT.value, "F6.3", 1, 10),
         (const.CDF_FLOAT.value, "F6.2", 1, 100),
         (const.CDF_FLOAT.value, "F6.1", 1, 1000),
-        (const.CDF_FLOAT.value, "G10.2E3", 1, -1),
+        (const.CDF_FLOAT.value, "G10.8E3", 1, -1),
     )
 
     with tempfile.TemporaryDirectory() as tmpdirname:

--- a/hermes_core/util/tests/test_schema.py
+++ b/hermes_core/util/tests/test_schema.py
@@ -306,24 +306,24 @@ def test_min_max_TT2000():
     """Get min/max values for TT2000 types"""
     minval, maxval = HermesDataSchema()._get_minmax(const.CDF_TIME_TT2000)
     # Make sure the minimum isn't just plain invalid
-    assert minval == datetime.datetime(1, 1, 1)
-    assert maxval == datetime.datetime(2292, 4, 11, 11, 46, 7, 670776)
+    assert minval == datetime.datetime(1900, 1, 1, 0, 0, 0, 0)
+    assert maxval == datetime.datetime(2250, 1, 1, 0, 0, 0, 0)
 
 
 def test_min_max_Epoch16():
     """Get min/max values for Epoch16 types"""
     minval, maxval = HermesDataSchema()._get_minmax(const.CDF_EPOCH16)
     # Make sure the minimum isn't just plain invalid
-    assert minval == datetime.datetime(1, 1, 1)
-    assert maxval == datetime.datetime(9999, 12, 31, 23, 59, 59)
+    assert minval == datetime.datetime(1900, 1, 1, 0, 0, 0, 0)
+    assert maxval == datetime.datetime(2250, 1, 1, 0, 0, 0, 0)
 
 
 def test_min_max_Epoch():
     """Get min/max values for EPOCH types"""
     minval, maxval = HermesDataSchema()._get_minmax(const.CDF_EPOCH)
     # Make sure the minimum isn't just plain invalid
-    assert minval == datetime.datetime(1, 1, 1)
-    assert maxval == datetime.datetime(9999, 12, 31, 23, 59, 59)
+    assert minval == datetime.datetime(1900, 1, 1, 0, 0, 0, 0)
+    assert maxval == datetime.datetime(2250, 1, 1, 0, 0, 0, 0)
 
 
 def test_min_max_Float():

--- a/hermes_core/util/tests/test_validation.py
+++ b/hermes_core/util/tests/test_validation.py
@@ -4,14 +4,15 @@ import pytest
 import tempfile
 import numpy as np
 from numpy.random import random
+import datetime
 from astropy.time import Time
 from astropy.timeseries import TimeSeries
 import astropy.units as u
 from spacepy.pycdf import CDF
 import hermes_core
 from hermes_core.timedata import HermesData
-from hermes_core.util.schema import HermesDataSchema
-from hermes_core.util.validation import validate
+from hermes_core.util import const
+from hermes_core.util.validation import validate, CDFValidator
 
 SAMPLE_CDF_FILE = "hermes_nms_default_l1_20160322_123031_v0.0.1.cdf"
 
@@ -128,3 +129,352 @@ def test_missing_variable_attrs():
             "Variable: measurement Attribute 'DISPLAY_TYPE' not one of valid options.",
             "Was bad_type, expected one of time_series time_series>noerrorbars spectrogram stack_plot image",
         ) in result
+
+
+def test_valid_range_dimensioned():
+    """Validmin/validmax with multiple elements"""
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Create a Test CDF
+        cdf = CDF(tmpdirname + "test.cdf", create=True)
+
+        v = cdf.new("var1", data=[[1, 10], [2, 20], [3, 30]])
+        v.attrs["VALIDMIN"] = [1, 20]
+        v.attrs["VALIDMAX"] = [3, 30]
+        v.attrs["FILLVAL"] = -100
+        errs = CDFValidator()._validrange(v)
+        assert 1 == len(errs)
+        assert "Value 10 at index [0 1] under VALIDMIN [ 1 20]." == errs[0]
+        v.attrs["VALIDMIN"] = [1, 10]
+        errs = CDFValidator()._validrange(v)
+        assert 0 == len(errs)
+        v[0, 0] = -100
+        errs = CDFValidator()._validrange(v)
+        assert 0 == len(errs)
+
+
+def test_valid_range_dimension_mismatch():
+    """Validmin/validmax with something wrong in dimensionality"""
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Create a Test CDF
+        cdf = CDF(tmpdirname + "test.cdf", create=True)
+
+        v = cdf.new("var1", data=[[1, 10], [2, 20], [3, 30]])
+        v.attrs["VALIDMIN"] = [1, 10, 100]
+        v.attrs["VALIDMAX"] = [3, 30, 127]
+        errs = CDFValidator()._validrange(v)
+        assert 2 == len(errs)
+        assert (
+            "VALIDMIN element count 3 does not match "
+            "first data dimension size 2." == errs[0]
+        )
+        assert (
+            "VALIDMAX element count 3 does not match "
+            "first data dimension size 2." == errs[1]
+        )
+
+
+def test_valid_range_high_dimension():
+    """Validmin/validmax with high-dimension variables"""
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Create a Test CDF
+        cdf = CDF(tmpdirname + "test.cdf", create=True)
+
+        v = cdf.new(
+            "var1",
+            data=np.reshape(
+                np.arange(27.0),
+                (
+                    3,
+                    3,
+                    3,
+                ),
+            ),
+        )
+        v.attrs["VALIDMIN"] = [1, 10, 100]
+        v.attrs["VALIDMAX"] = [3, 30, 300]
+        errs = CDFValidator()._validrange(v)
+        assert 2 == len(errs)
+        assert "Multi-element VALIDMIN only valid with 1D variable." == errs[0]
+        assert "Multi-element VALIDMAX only valid with 1D variable." == errs[1]
+
+
+def test_valid_range_wrong_type():
+    """Validmin/validmax not matching variable type"""
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Create a Test CDF
+        cdf = CDF(tmpdirname + "test.cdf", create=True)
+
+        v = cdf.new("var1", data=[1, 2, 3], type=const.CDF_INT4)
+        v.attrs.new("VALIDMIN", data=1, type=const.CDF_INT2)
+        v.attrs.new("VALIDMAX", data=3, type=const.CDF_INT2)
+        errs = CDFValidator()._validrange(v)
+        errs.sort()
+        assert 0 == len(errs)
+
+
+def test_valid_range_incompatible_type():
+    """Validmin/validmax can't be compared to variable type"""
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Create a Test CDF
+        cdf = CDF(tmpdirname + "test.cdf", create=True)
+
+        v = cdf.new("var1", data=[1, 2, 3], type=const.CDF_INT4)
+        v.attrs.new("VALIDMIN", data="2")
+        v.attrs.new("VALIDMAX", data="5")
+        errs = CDFValidator()._validrange(v)
+        errs.sort()
+        assert 2 == len(errs)
+        assert [
+            "VALIDMAX type CDF_CHAR not comparable to variable type CDF_INT4.",
+            "VALIDMIN type CDF_CHAR not comparable to variable type CDF_INT4.",
+        ] == errs
+
+
+def test_valid_range_nrv():
+    """Validmin/validmax"""
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Create a Test CDF
+        cdf = CDF(tmpdirname + "test.cdf", create=True)
+
+        v = cdf.new("var1", recVary=False, data=[1, 2, 3])
+        v.attrs["VALIDMIN"] = 1
+        v.attrs["VALIDMAX"] = 3
+        assert 0 == len(CDFValidator()._validrange(v))
+        v.attrs["VALIDMIN"] = 2
+        errs = CDFValidator()._validrange(v)
+        assert 1 == len(errs)
+        assert "Value 1 at index 0 under VALIDMIN 2." == errs[0]
+        v.attrs["VALIDMAX"] = 2
+        errs = CDFValidator()._validrange(v)
+        assert 2 == len(errs)
+        assert "Value 3 at index 2 over VALIDMAX 2." == errs[1]
+
+
+def test_valid_range_nrv_fillval():
+    """Validmin/validmax with fillval set"""
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Create a Test CDF
+        cdf = CDF(tmpdirname + "test.cdf", create=True)
+
+        v = cdf.new("var1", recVary=False, data=[1, 2, 3])
+        v.attrs["VALIDMIN"] = 1
+        v.attrs["VALIDMAX"] = 3
+        v.attrs["FILLVAL"] = 99
+        assert 0 == len(CDFValidator()._validrange(v))
+
+        v.attrs["VALIDMIN"] = 2
+        errs = CDFValidator()._validrange(v)
+        assert 1 == len(errs)
+        assert "Value 1 at index 0 under VALIDMIN 2." == errs[0]
+
+        v.attrs["VALIDMAX"] = 2
+        errs = CDFValidator()._validrange(v)
+        assert 2 == len(errs)
+        assert "Value 3 at index 2 over VALIDMAX 2." == errs[1]
+
+        v.attrs["FILLVAL"] = 3
+        errs = CDFValidator()._validrange(v)
+        assert 1 == len(errs)
+        assert "Value 1 at index 0 under VALIDMIN 2." == errs[0]
+
+        v.attrs["FILLVAL"] = 1
+        errs = CDFValidator()._validrange(v)
+        assert 1 == len(errs)
+        assert "Value 3 at index 2 over VALIDMAX 2." == errs[0]
+
+
+def test_valid_range_fillval_float():
+    """Validmin/validmax with fillval set, floating-point"""
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Create a Test CDF
+        cdf = CDF(tmpdirname + "test.cdf", create=True)
+
+        v = cdf.new("var1", recVary=False, data=[1, 2, 3], type=const.CDF_DOUBLE)
+        v.attrs["VALIDMIN"] = 0
+        v.attrs["VALIDMAX"] = 10
+        # This is a bit contrived to force a difference between attribute
+        # and value that's only the precision of the float
+        v.attrs.new("FILLVAL", -1e31, type=const.CDF_FLOAT)
+        assert 0 == len(CDFValidator()._validrange(v))
+
+        v[0] = -100
+        errs = CDFValidator()._validrange(v)
+        assert 1 == len(errs)
+        assert "Value -100.0 at index 0 under VALIDMIN 0.0." == errs[0]
+
+        v[0] = -1e31
+        assert 0 == len(CDFValidator()._validrange(v))
+
+
+def test_valid_range_fillval_float_wrong_type():
+    """Validmin/validmax with fillval, floating-point, but fillval string"""
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Create a Test CDF
+        cdf = CDF(tmpdirname + "test.cdf", create=True)
+
+        v = cdf.new("var1", recVary=False, data=[-1e31, 2, 3], type=const.CDF_DOUBLE)
+        v.attrs["VALIDMIN"] = 0
+        v.attrs["VALIDMAX"] = 10
+        v.attrs.new("FILLVAL", b"badstuff", type=const.CDF_CHAR)
+        expected = ["Value -1e+31 at index 0 under VALIDMIN 0.0."]
+        errs = CDFValidator()._validrange(v)
+        assert len(expected) == len(errs)
+        for a, e in zip(sorted(errs), sorted(expected)):
+            assert e == a
+
+
+def test_valid_range_fillval_datetime():
+    """Validmin/validmax with fillval set, Epoch var"""
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Create a Test CDF
+        cdf = CDF(tmpdirname + "test.cdf", create=True)
+
+        v = cdf.new(
+            "var1",
+            data=[datetime.datetime(2010, 1, i) for i in range(1, 6)],
+            type=const.CDF_EPOCH,
+        )
+        v.attrs["VALIDMIN"] = datetime.datetime(2010, 1, 1)
+        v.attrs["VALIDMAX"] = datetime.datetime(2010, 1, 31)
+        v.attrs["FILLVAL"] = datetime.datetime(9999, 12, 31, 23, 59, 59, 999000)
+        assert 0 == len(CDFValidator()._validrange(v))
+
+        v[-1] = datetime.datetime(2010, 2, 1)
+        errs = CDFValidator()._validrange(v)
+        assert 1 == len(errs)
+        assert (
+            "Value 2010-02-01 00:00:00 at index 4 over VALIDMAX "
+            "2010-01-31 00:00:00." == errs[0]
+        )
+
+        v[-1] = datetime.datetime(9999, 12, 31, 23, 59, 59, 999000)
+        assert 0 == len(CDFValidator()._validrange(v))
+
+
+def test_valid_range_scalar():
+    """Check validmin/max on a scalar"""
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Create a Test CDF
+        cdf = CDF(tmpdirname + "test.cdf", create=True)
+
+        v = cdf.new("var1", recVary=False, data=1)
+        v.attrs["VALIDMIN"] = 0
+        v.attrs["VALIDMAX"] = 2
+        v.attrs["FILLVAL"] = -100
+        assert 0 == len(CDFValidator()._validrange(v))
+        v.attrs["VALIDMIN"] = 2
+        v.attrs["VALIDMAX"] = 3
+        errs = CDFValidator()._validrange(v)
+        assert 1 == len(errs)
+        assert "Value 1 under VALIDMIN 2." == errs[0]
+
+
+def test_valid_scale():
+    """Check scale min and max."""
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Create a Test CDF
+        cdf = CDF(tmpdirname + "test.cdf", create=True)
+
+        v = cdf.new("var1", recVary=False, data=[1, 2, 3])
+        v.attrs["SCALEMIN"] = 1
+        v.attrs["SCALEMAX"] = 3
+        assert 0 == len(CDFValidator()._validscale(v))
+        v.attrs["SCALEMIN"] = 5
+        v.attrs["SCALEMAX"] = 3
+        assert 1 == len(CDFValidator()._validscale(v))
+        errs = CDFValidator()._validscale(v)
+        assert "SCALEMIN > SCALEMAX." == errs[0]
+        v.attrs["SCALEMIN"] = -200
+        errs = CDFValidator()._validscale(v)
+        assert 1 == len(errs)
+        errs.sort()
+        assert ["SCALEMIN (-200) outside valid data range (-128,127)."] == errs
+        v.attrs["SCALEMIN"] = 200
+        errs = CDFValidator()._validscale(v)
+        assert 2 == len(errs)
+        errs.sort()
+        assert [
+            "SCALEMIN (200) outside valid data range (-128,127).",
+            "SCALEMIN > SCALEMAX.",
+        ] == errs
+        v.attrs["SCALEMAX"] = -200
+        errs = CDFValidator()._validscale(v)
+        assert 3 == len(errs)
+        errs.sort()
+        assert [
+            "SCALEMAX (-200) outside valid data range (-128,127).",
+            "SCALEMIN (200) outside valid data range (-128,127).",
+            "SCALEMIN > SCALEMAX.",
+        ] == errs
+        v.attrs["SCALEMAX"] = 200
+        errs = CDFValidator()._validscale(v)
+        assert 2 == len(errs)
+        errs.sort()
+        assert [
+            "SCALEMAX (200) outside valid data range (-128,127).",
+            "SCALEMIN (200) outside valid data range (-128,127).",
+        ] == errs
+
+
+def test_valid_scale_dimensioned():
+    """Validmin/validmax with multiple elements"""
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Create a Test CDF
+        cdf = CDF(tmpdirname + "test.cdf", create=True)
+
+        v = cdf.new("var1", data=[[1, 10], [2, 20], [3, 30]])
+        v.attrs["SCALEMIN"] = [2, 20]
+        v.attrs["SCALEMAX"] = [300, 320]
+        v.attrs["FILLVAL"] = -100
+        errs = CDFValidator()._validscale(v)
+        assert 1 == len(errs)
+        errs.sort()
+        assert [
+            "SCALEMAX ([300 320]) outside valid data range (-128,127).",
+        ] == errs
+        v.attrs["SCALEMAX"] = [30, 32]
+        errs = CDFValidator()._validscale(v)
+        assert 0 == len(errs)
+
+
+def test_valid_scale_dimension_mismatch():
+    """Validmin/validmax with something wrong in dimensionality"""
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Create a Test CDF
+        cdf = CDF(tmpdirname + "test.cdf", create=True)
+
+        v = cdf.new("var1", data=[[1, 10], [2, 20], [3, 30]])
+        v.attrs["SCALEMIN"] = [1, 10, 100]
+        v.attrs["SCALEMAX"] = [3, 30, 126]
+        errs = CDFValidator()._validscale(v)
+        assert 2 == len(errs)
+        errs.sort()
+        assert [
+            "SCALEMAX element count 3 does not match " "first data dimension size 2.",
+            "SCALEMIN element count 3 does not match " "first data dimension size 2.",
+        ] == errs
+
+
+def test_valid_scale_high_dimension():
+    """scalemin/scalemax with high-dimension variables"""
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Create a Test CDF
+        cdf = CDF(tmpdirname + "test.cdf", create=True)
+
+        v = cdf.new(
+            "var1",
+            data=np.reshape(
+                np.arange(27.0),
+                (
+                    3,
+                    3,
+                    3,
+                ),
+            ),
+        )
+        v.attrs["SCALEMIN"] = [1, 10, 100]
+        v.attrs["SCALEMAX"] = [3, 30, 300]
+        errs = CDFValidator()._validscale(v)
+        assert 2 == len(errs)
+        assert "Multi-element SCALEMIN only valid with 1D variable." == errs[0]
+        assert "Multi-element SCALEMAX only valid with 1D variable." == errs[1]

--- a/hermes_core/util/tests/test_validation.py
+++ b/hermes_core/util/tests/test_validation.py
@@ -116,7 +116,6 @@ def test_missing_variable_attrs():
             del cdf["measurement"].meta["CATDESC"]
             del cdf["measurement"].meta["UNITS"]
             cdf["measurement"].meta["DISPLAY_TYPE"] = "bad_type"
-            cdf["measurement"].meta["FORMAT"] = "bad_format"
 
         # Validate
         result = validate(out_file)
@@ -129,7 +128,3 @@ def test_missing_variable_attrs():
             "Variable: measurement Attribute 'DISPLAY_TYPE' not one of valid options.",
             "Was bad_type, expected one of time_series time_series>noerrorbars spectrogram stack_plot image",
         ) in result
-        assert (
-            "Variable: measurement Attribute 'FORMAT' value 'bad_format' does not match derrived format 'I5'"
-            in result
-        )

--- a/hermes_core/util/validation.py
+++ b/hermes_core/util/validation.py
@@ -209,11 +209,6 @@ class CDFValidator(HermesDataValidator):
                                 f"Was {attr_value}, expected one of {attr_valid_values}",
                             )
                         )
-        # Validate `FORMAT` Attribute on the Variable
-        if "FORMAT" in var_type_attrs and "FORMAT" in var_data.meta:
-            format_errors = self._validate_format(cdf_file=cdf_file, var_name=var_name)
-            if format_errors:
-                variable_errors.append(format_errors)
 
         # Validate Variable using ISTP Module `VariableChecks` class
         variable_checks_errors = self._variable_checks(
@@ -222,19 +217,6 @@ class CDFValidator(HermesDataValidator):
         variable_errors.extend(variable_checks_errors)
 
         return variable_errors
-
-    def _validate_format(self, cdf_file: CDF, var_name: str):
-        # Save the Current Format
-        variable_format = cdf_file[var_name].meta["FORMAT"]
-        # Get the target Format for the Variable
-        target_format = self.schema._get_format(
-            var_data=cdf_file[var_name], cdftype=cdf_file[var_name].type()
-        )
-
-        if variable_format != target_format:
-            return f"Variable: {var_name} Attribute 'FORMAT' value '{variable_format}' does not match derrived format '{target_format}'"
-        else:
-            return None
 
     def _file_checks(self, cdf_file: CDF):
         """
@@ -282,13 +264,19 @@ class CDFValidator(HermesDataValidator):
             # This function makes incorrect assumptions that the variable name must exactly
             # match the FILEDNAM metadata attribute.
             # VariableChecks.fieldnam,
-            VariableChecks.fillval,
+            # This function makes incorrect assumtions that the FILLVAL must be derived from
+            # the CDF data type of the variable. A FILLVAL should be allowed to be set as needed by
+            # instrument team developers.
+            # VariableChecks.fillval,
             VariableChecks.recordcount,
             # This function makes incorrect assumptions about the valid DISPLAY_TYPE options
             # based on the shape of the variable data.
             # VariableChecks.validdisplaytype,
-            VariableChecks.validrange,
-            VariableChecks.validscale,
+            # This Function makes inforrect assumptions that the VLIDMIN and VLIDIMAX must be
+            # derived from the CDF data type of the variable. A VALIDMIN and VALIDMAX should be
+            # allowed to be set as needed by instrument team developers.
+            # VariableChecks.validrange,
+            # VariableChecks.validscale,
         ]
 
         # Loop through the Functions we want to check


### PR DESCRIPTION
* Updates the default FORMAT variable metadata attribute
* Updates the schema policy so FORMAT, VALIDMIN/MAX, FILLVAL are not overwritten. 
* Updates variable attribute validation to skip FORMAT, and FILLVAL which were based on the data type of the attribute
* Updates validation for VALIDMIN/MAX from spacepy which was based on the data type of the attribute. Modified version still checks range and dimensionality, but not that the data types are en exact match. 

closes #98 
closes #99