### PR TITLE
Update TimeSeries Column Requirements

### DIFF
--- a/hermes_core/tests/test_timedata.py
+++ b/hermes_core/tests/test_timedata.py
@@ -83,6 +83,23 @@ def test_hermes_data_empty_ts():
         _ = HermesData(timeseries=TimeSeries())
 
 
+def test_hermes_data_single_column():
+    ts = TimeSeries()
+
+    # Create an astropy.Time object
+    time = np.arange(10)
+    time_col = Time(time, format="unix")
+    ts["time"] = time_col
+
+    # Meta
+    input_attrs = HermesData.global_attribute_template("eea", "l1", "1.0.0")
+
+    # Create TimeSeries with only Time - no measurements
+    hermes_data = HermesData(timeseries=ts, meta=input_attrs)
+
+    assert len(hermes_data.timeseries.columns) == 1
+
+
 def test_hermes_data_bad_ts():
     ts = get_bad_timeseries()
     with pytest.raises(TypeError):

--- a/hermes_core/timedata.py
+++ b/hermes_core/timedata.py
@@ -72,8 +72,11 @@ class HermesData:
             raise TypeError(
                 "timeseries must be a `astropy.timeseries.TimeSeries` object."
             )
-        if len(timeseries.columns) < 2:
-            raise ValueError("timeseries must have at least 2 columns")
+
+        if len(timeseries) == 0:
+            raise ValueError(
+                "timeseries cannot be empty, must include at least a 'time' column with valid times"
+            )
 
         # Check individual Columns
         for colname in timeseries.columns:


### PR DESCRIPTION
*  Relaxes the requirements that the `astropy.timeseries.TimeSeries` member must have at least two columns, one `time` and then one other measurement.
* A `HermesData` can be create with a `TimeSeries` that contains only `time`. An error will still be thrown if `time` is not included. 
closes #103 