### PR TITLE
Add Global Metadata Validation Checks

### DIFF
--- a/hermes_core/tests/test_timedata.py
+++ b/hermes_core/tests/test_timedata.py
@@ -102,6 +102,57 @@ def test_hermes_data_default():
     del ts
 
 
+def test_hermes_data_missing_descriptor():
+    ts = get_test_timeseries()
+    input_attrs = {}
+
+    with pytest.raises(ValueError) as excinfo:
+        # We expect this to throw an error that 'Descriptor' is required
+        _ = HermesData(ts, meta=input_attrs)
+
+        assert (
+            str(excinfo.value)
+            == "'Descriptor' gloabl meta attribute required for HERMES Instrument name"
+        )
+
+    # Test Deleting the Writer
+    del ts
+
+
+def test_hermes_data_missing_data_level():
+    ts = get_test_timeseries()
+    input_attrs = HermesData.global_attribute_template("eea")
+
+    with pytest.raises(ValueError) as excinfo:
+        # We expect this to throw an error that 'Descriptor' is required
+        _ = HermesData(ts, meta=input_attrs)
+
+        assert (
+            str(excinfo.value)
+            == "'Data_level' global meta attribute required for HERMES data level"
+        )
+
+    # Test Deleting the Writer
+    del ts
+
+
+def test_hermes_data_missing_data_version():
+    ts = get_test_timeseries()
+    input_attrs = HermesData.global_attribute_template("eea", "l1")
+
+    with pytest.raises(ValueError) as excinfo:
+        # We expect this to throw an error that 'Descriptor' is required
+        _ = HermesData(ts, meta=input_attrs)
+
+        assert (
+            str(excinfo.value)
+            == "'Data_version' global meta attribute is required for HERMES data version"
+        )
+
+    # Test Deleting the Writer
+    del ts
+
+
 def test_multidimensional_data():
     ts = get_test_timeseries()
     ts["var"] = Quantity(value=random(size=(10, 2)), unit="s", dtype=np.uint16)

--- a/hermes_core/tests/test_timedata.py
+++ b/hermes_core/tests/test_timedata.py
@@ -112,7 +112,7 @@ def test_hermes_data_missing_descriptor():
 
         assert (
             str(excinfo.value)
-            == "'Descriptor' gloabl meta attribute required for HERMES Instrument name"
+            == "'Descriptor' global meta attribute required for HERMES Instrument name"
         )
 
     # Test Deleting the Writer

--- a/hermes_core/timedata.py
+++ b/hermes_core/timedata.py
@@ -104,7 +104,7 @@ class HermesData:
         # Check Global Metadata Requirements - Require Descriptor, Data_level, Data_Version
         if "Descriptor" not in _meta or _meta["Descriptor"] is None:
             raise ValueError(
-                "'Descriptor' gloabl meta attribute required for HERMES Instrument name"
+                "'Descriptor' global meta attribute required for HERMES Instrument name"
             )
         if "Data_level" not in _meta or _meta["Data_level"] is None:
             raise ValueError(

--- a/hermes_core/timedata.py
+++ b/hermes_core/timedata.py
@@ -67,6 +67,10 @@ class HermesData:
         ] = None,
         meta: Optional[dict] = None,
     ):
+        # ================================================
+        #               VALIDATE INPUTS
+        # ================================================
+
         # Verify TimeSeries compliance
         if not isinstance(timeseries, TimeSeries):
             raise TypeError(
@@ -88,6 +92,29 @@ class HermesData:
                     f"Column '{colname}' must be a one-dimensional measurement. Split additional dimensions into unique measurenents."
                 )
 
+        # Global Metadata Attributes are compiled from two places. You can pass in
+        # global metadata throug the `meta` parameter or through the `TimeSeries.meta`
+        # attribute.
+        _meta = {}
+        if meta is not None and isinstance(meta, dict):
+            _meta.update(meta)
+        if timeseries.meta is not None and isinstance(timeseries.meta, dict):
+            _meta.update(timeseries.meta)
+
+        # Check Global Metadata Requirements - Require Descriptor, Data_level, Data_Version
+        if "Descriptor" not in _meta or _meta["Descriptor"] is None:
+            raise ValueError(
+                "'Descriptor' gloabl meta attribute required for HERMES Instrument name"
+            )
+        if "Data_level" not in _meta or _meta["Data_level"] is None:
+            raise ValueError(
+                "'Data_level' global meta attribute required for HERMES data level"
+            )
+        if "Data_version" not in _meta or _meta["Data_version"] is None:
+            raise ValueError(
+                "'Data_version' global meta attribute is required for HERMES data version"
+            )
+
         # Check NRV Data
         if support:
             for key in support:
@@ -98,6 +125,10 @@ class HermesData:
                     raise TypeError(
                         f"Variable '{key}' must be an astropy.units.Quantity or astropy.nddata.NDData object"
                     )
+
+        # ================================================
+        #         CREATE HERMES DATA STRUCTURES
+        # ================================================
 
         # Copy the TimeSeries
         self._timeseries = TimeSeries(timeseries, copy=True)
@@ -111,7 +142,7 @@ class HermesData:
         if hasattr(timeseries["time"], "meta"):
             self._timeseries["time"].meta.update(timeseries["time"].meta)
 
-        # Add Measurement Metadata
+        # Add TimeSeries Measurement Metadata
         for col in self._timeseries.columns:
             if col != "time":
                 self._timeseries[col].meta = self.measurement_attribute_template()
@@ -130,6 +161,10 @@ class HermesData:
                 self._support[key].meta.update(support[key].meta)
             else:
                 self._support[key].meta = self.measurement_attribute_template()
+
+        # ================================================
+        #           DERIVE METADATA ATTRIBUTES
+        # ================================================
 
         # Derive Metadata
         self.schema = HermesDataSchema()

--- a/hermes_core/util/tests/test_schema.py
+++ b/hermes_core/util/tests/test_schema.py
@@ -62,7 +62,7 @@ def test_hermes_data_schema():
     assert schema.variable_attribute_schema is not None
     assert isinstance(schema.variable_attribute_schema, dict)
 
-    # Default Globla Attributes
+    # Default Global Attributes
     assert schema.default_global_attributes is not None
     assert isinstance(schema.default_global_attributes, dict)
 


### PR DESCRIPTION
* Adds immediate validation checks on required pieces of global metadata. These would throw harder-to-read errors later during derivation. Better practice now to raise the error as early as possible.

closes #101 