### PR TITLE
Add rstcheck

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,5 +24,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: rstcheck
+      run: |
+        python -m pip install -e '.[style]'
+        rstcheck -r docs 
     - name: Build docs
       run: sphinx-build docs docs/_build/html -W -b html

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,16 +21,21 @@ repos:
   # E902 - IOError
   # F822: undefined name in __all__
   # F823: local variable name referenced before assignment
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
-    hooks:
-      - id: flake8
-        args: ['--count', '--select', 'E101,E11,E111,E112,E113,E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E133,E20,E211,E231,E241,E242,E251,E252,E26,E265,E266,E27,E301,E302,E303,E304,E305,E306,E401,E402,E502,E701,E711,E712,E713,E714,E722,E731,E901,E902,F822,F823,W191,W291,W292,W293,W391,W601,W602,W603,W604,W605,W690']
+  # - repo: https://gitlab.com/pycqa/flake8
+  #   rev: 3.7.9
+  #   hooks:
+  #     - id: flake8
+  #       args: ['--count', '--select', 'E101,E11,E111,E112,E113,E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E133,E20,E211,E231,E241,E242,E251,E252,E26,E265,E266,E27,E301,E302,E303,E304,E305,E306,E401,E402,E502,E701,E711,E712,E713,E714,E722,E731,E901,E902,F822,F823,W191,W291,W292,W293,W391,W601,W602,W603,W604,W605,W690']
 
   - repo: https://github.com/psf/black
     rev: 21.6b0
     hooks:
       - id: black
+
+  - repo: https://github.com/rstcheck/rstcheck
+    rev: v6.2.0
+    hooks:
+    -   id: rstcheck
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,11 +21,11 @@ repos:
   # E902 - IOError
   # F822: undefined name in __all__
   # F823: local variable name referenced before assignment
-  # - repo: https://gitlab.com/pycqa/flake8
-  #   rev: 3.7.9
-  #   hooks:
-  #     - id: flake8
-  #       args: ['--count', '--select', 'E101,E11,E111,E112,E113,E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E133,E20,E211,E231,E241,E242,E251,E252,E26,E265,E266,E27,E301,E302,E303,E304,E305,E306,E401,E402,E502,E701,E711,E712,E713,E714,E722,E731,E901,E902,F822,F823,W191,W291,W292,W293,W391,W601,W602,W603,W604,W605,W690']
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+      - id: flake8
+        args: ['--count', '--select', 'E101,E11,E111,E112,E113,E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E133,E20,E211,E231,E241,E242,E251,E252,E26,E265,E266,E27,E301,E302,E303,E304,E305,E306,E401,E402,E502,E701,E711,E712,E713,E714,E722,E731,E901,E902,F822,F823,W191,W291,W292,W293,W391,W601,W602,W603,W604,W605,W690']
 
   - repo: https://github.com/psf/black
     rev: 21.6b0

--- a/docs/user-guide/cdf_format_guide.rst
+++ b/docs/user-guide/cdf_format_guide.rst
@@ -194,19 +194,19 @@ Attributes Webpage <http://spdf.gsfc.nasa.gov/istp_guide/gattributes.html>`_.
 --------------------------------------
 
 The following global attributes shown in Table 4-1 are required with HERMES data products.
-HERMES-specific values are provided where applicable. For each attribute the following 
+HERMES-specific values are provided where applicable. For each attribute the following
 information is provided:
 
 * description: (`str`) A brief description of the attribute
 * default: (`str`) The default value used if none is provided
-* derived: (`bool`) Whether the attibute can be derived by the HERMES 
+* derived: (`bool`) Whether the attibute can be derived by the HERMES
   :py:class:`~hermes_core.util.schema.HermesDataSchema` class
 * required: (`bool`) Whether the attribute is required by HERMES standards
-* validate: (`bool`) Whether the attribute is included in the 
-  :py:func:`~hermes_core.util.validation.validate` checks (Note, not all attributes that 
+* validate: (`bool`) Whether the attribute is included in the
+  :py:func:`~hermes_core.util.validation.validate` checks (Note, not all attributes that
   are required are validated)
 * overwrite: (`bool`) Whether the :py:class:`~hermes_core.util.schema.HermesDataSchema`
-  attribute derivations will overwrite an existing attribute value with an updated 
+  attribute derivations will overwrite an existing attribute value with an updated
   attribute value from the derivation process.
 
 Note that this table is derived from :file:`hermes_core/data/hermes_default_global_cdf_attrs_schema.yaml`
@@ -258,10 +258,10 @@ products. HERMES-specific values are provided where applicable.
 5. Variables
 ============
 
-There are three types of variables that should be included in CDF files: 
-* data, 
+There are three types of variables that should be included in CDF files:
+* data,
 * support data,
-* metadata. 
+* metadata.
 
 Additionally, required attributes are listed with each variable type listed
 below.
@@ -338,7 +338,7 @@ in Table 5-2. An example data variable would be `hermes_eea_n_gse_l2`.
 Note the following caveats in the variable naming conventions:
 
 * CDF variable names must begin with a letter and can contain numbers and underscores, but no other special characters.
-* In general, the instrumentId field follows the convention used for file names as defined in Section 3.1. 
+* In general, the instrumentId field follows the convention used for file names as defined in Section 3.1.
   However, since variable names cannot contain a hyphen, an underscore should be used instead of a hyphen when needing to separate
   instrument components. For instance, "eea-ion" is a valid instrumentId in a
   filename but when used in a variable name, "eea_ion" should be used instead.
@@ -346,7 +346,7 @@ Note the following caveats in the variable naming conventions:
   will consist of all lowercase characters.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-5.1.2 Required Epoch Variable 
+5.1.2 Required Epoch Variable
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 All HERMES CDF data files must contain at least one variable of data type
@@ -363,7 +363,7 @@ For ISTP, but not necessarily for all HERMES data, the time value of a record re
 to the center of the accumulation period for the record if the measurement is not an
 instantaneous one. All HERMES time variables used as DEPEND_0 are strongly
 recommended to have DELTA_PLUS_VAR and DELTA_MINUS_VAR attributes which delineate the
-time interval over which the data was sampled, integrated, or otherwise representative 
+time interval over which the data was sampled, integrated, or otherwise representative
 of. This also locates the timetag within that interval.
 
 The epoch datatype, CDF_TIME_TT2000, is defined as an 8-byte signed integer with the
@@ -392,8 +392,8 @@ leap seconds since 1960; for example, for 2009, deltaAT = 34s). Pad values of -
 9223372036854775808 (0x8000000000000000) which corresponds to 1707-09-
 22T12:13:15.145224192; recommended FILLVAL is same.
 
-It is proposed that the required data variables VALIDMIN and VALIDMAX are given values 
-corresponding to the dates 1990-01-01T00:00:00 and 2100-01-01T00:00:00 as these are well 
+It is proposed that the required data variables VALIDMIN and VALIDMAX are given values
+corresponding to the dates 1990-01-01T00:00:00 and 2100-01-01T00:00:00 as these are well
 outside any expected valid times.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -474,9 +474,9 @@ underscores, but no other special characters. Support data variable names need n
 the same naming convention as Data Variables (5.1.1) but may be shortened for
 convenience.
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-5.3.2 Required Attributes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5.3.2 Required Attributes: Support Variables
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * CATDESC
 * DEPEND_0 (if time varying)
@@ -508,9 +508,9 @@ Metadata variable names must begin with a letter and can contain numbers and
 underscores, but no other special characters. Metadata variable names need not follow the
 same naming convention as Data Variables (5.1.1) but may be shortened for convenience.
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-5.3.2 Required Attributes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5.4.2 Required Attributes: Metadata Variables
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * CATDESC
 * DEPEND_0 (if time varying, this value must be “Epoch”)
@@ -524,24 +524,24 @@ same naming convention as Data Variables (5.1.1) but may be shortened for conven
 --------------------------------------
 
 The following variable attributes shown in Table 5-4 are required with HERMES data products.
-HERMES-specific values are provided where applicable. For each attribute the following 
+HERMES-specific values are provided where applicable. For each attribute the following
 information is provided:
 
 * description: (`str`) A brief description of the attribute
-* derived: (`bool`) Whether the attibute can be derived by the HERMES 
+* derived: (`bool`) Whether the attibute can be derived by the HERMES
   :py:class:`~hermes_core.util.schema.HermesDataSchema` class
 * required: (`bool`) Whether the attribute is required by HERMES standards
 * overwrite: (`bool`) Whether the :py:class:`~hermes_core.util.schema.HermesDataSchema`
-  attribute derivations will overwrite an existing attribute value with an updated 
+  attribute derivations will overwrite an existing attribute value with an updated
   attribute value from the derivation process.
 * valid_values: (`list`) List of allowed values the attribute can take for HERMES products,
   if applicable
-* alternate: (`str`) An additional attribute name that can be treated as an alternative 
-  of the given attribute. Not all attributes have an alternative and only one of a given 
-  attribute or its alternate are required. 
+* alternate: (`str`) An additional attribute name that can be treated as an alternative
+  of the given attribute. Not all attributes have an alternative and only one of a given
+  attribute or its alternate are required.
 * var_types: (`str`) A list of the variable types that require the given
   attribute to be present.
-  
+
 Note that this table is derived from :file:`hermes_core/data/hermes_default_variable_cdf_attrs_schema.yaml`
 
 .. csv-table:: Table 5-4 HERMES Variable Attribute Schema

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,8 @@ test = [
 
 style = [
   'black',
-  'flake8'
+  'flake8',
+  'rstcheck',
 ]
 
 [tool.setuptools.package-data]
@@ -99,3 +100,17 @@ omit = [
   '*/hermes_core/version*',
 ]
 
+[tool.rstcheck]
+report_level = "WARNING"
+ignore_roles = [
+  "py:class",
+  "py:class",
+  "file",
+]
+ignore_directives = [
+    "plot",
+    "doctest",
+    "automodapi",
+    "csv-table",
+]
+ignore_messages = "not referenced"


### PR DESCRIPTION
This PR adds a package `rstcheck` which validates syntax and formatting of `.rst` based Sphinx documentation. The advantage of adding this package is that it can report simple errors in docs formatting without needing to build the documentation, either locally or in the pipeline. The `rstcheck` tool is added both as a pre-commit hook as well as a pipeline step in the `docs` pipeline.

To run the `rstcheck` tool locally you can use the following command from the root of the `hermes_core` repository. 
```bash
rstcheck -r docs
```

closes #96 
