### PR TITLE
Convert Datetime to Astropy Time

### DIFF
--- a/hermes_core/tests/test_timedata.py
+++ b/hermes_core/tests/test_timedata.py
@@ -169,6 +169,18 @@ def test_hermes_data_missing_data_version():
     del ts
 
 
+def test_none_attributes():
+    test_data = get_test_hermes_data()
+
+    # Add a Variable Attribute with Value None
+    test_data.timeseries["time"].meta["none_attr"] = None
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        with pytest.raises(ValueError):
+            # Throws an error that we cannot have None attribute values
+            test_data.save(output_path=tmpdirname)
+
+
 def test_multidimensional_data():
     ts = get_test_timeseries()
     ts["var"] = Quantity(value=random(size=(10, 2)), unit="s", dtype=np.uint16)

--- a/hermes_core/tests/test_timedata.py
+++ b/hermes_core/tests/test_timedata.py
@@ -2,7 +2,6 @@
 
 from collections import OrderedDict
 from pathlib import Path
-import datetime
 import pytest
 import numpy as np
 from numpy.random import random
@@ -25,7 +24,7 @@ def get_bad_timeseries():
 
     # Create an astropy.Time object
     time = np.arange(10)
-    time_col = Time(time, format="unix").to_datetime()
+    time_col = Time(time, format="unix")
     col = Column(data=time_col, name="time", meta={})
     ts.add_column(col)
 
@@ -261,7 +260,7 @@ def test_default_properties():
         "Descriptor": "EEA>Electron Electrostatic Analyzer",
         "Data_level": "l1>Level 1",
         "Data_version": "v0.0.1",
-        "Start_time": datetime.datetime.now()
+        "Start_time": Time.now()
     }
     # fmt: on
 
@@ -469,7 +468,7 @@ def test_hermes_data_append():
     # Append Not-Enough Columns
     ts = TimeSeries()
     time = np.arange(start=10, stop=20)
-    time_col = Time(time, format="unix").to_datetime()
+    time_col = Time(time, format="unix")
     col = Column(data=time_col, name="time", meta={})
     ts.add_column(col)
     with pytest.raises(ValueError):
@@ -478,7 +477,7 @@ def test_hermes_data_append():
     # Append Too-Many Columns
     ts = TimeSeries()
     time = np.arange(start=10, stop=20)
-    time_col = Time(time, format="unix").to_datetime()
+    time_col = Time(time, format="unix")
     col = Column(data=time_col, name="time", meta={})
     ts.add_column(col)
     ts["test1"] = Quantity(value=random(size=(10)), unit="m", dtype=np.uint16)

--- a/hermes_core/util/io.py
+++ b/hermes_core/util/io.py
@@ -230,9 +230,6 @@ class CDFHandler(HermesDataIOHandler):
             # We cannot add None Values to the CDF Global Attrs
             if attr_value is None:
                 cdf_file.attrs[attr_name] = ""
-            elif isinstance(attr_value, Time):
-                # Convert the Attribute to Datetime before adding to CDF File
-                cdf_file.attrs[attr_name] = attr_value.to_datetime()
             else:
                 # Add the Attribute to the CDF File
                 cdf_file.attrs[attr_name] = attr_value

--- a/hermes_core/util/io.py
+++ b/hermes_core/util/io.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Tuple
 from collections import OrderedDict
+from datetime import datetime
 from astropy.timeseries import TimeSeries
 from astropy.time import Time
 from astropy.nddata import NDData
@@ -118,9 +119,7 @@ class CDFHandler(HermesDataIOHandler):
             # First Variable we need to add is time/Epoch
             if "Epoch" in input_file:
                 time_data = Time(input_file["Epoch"][:].copy())
-                time_attrs = {}
-                for attr_name in input_file["Epoch"].attrs:
-                    time_attrs[attr_name] = input_file["Epoch"].attrs[attr_name]
+                time_attrs = self._load_metadata_attributes(input_file["Epoch"])
                 # Create the Time object
                 ts["time"] = time_data
                 # Create the Metadata
@@ -142,9 +141,7 @@ class CDFHandler(HermesDataIOHandler):
                     continue
 
                 # Extract the Variable's Metadata
-                var_attrs = {}
-                for attr_name in input_file[var_name].attrs:
-                    var_attrs[attr_name] = input_file[var_name].attrs[attr_name]
+                var_attrs = self._load_metadata_attributes(input_file[var_name])
 
                 # Extract the Variable's Data
                 var_data = input_file[var_name][...]
@@ -173,6 +170,17 @@ class CDFHandler(HermesDataIOHandler):
 
         # Return the given TimeSeries, NRV Data
         return ts, support
+
+    def _load_metadata_attributes(self, var_data):
+        var_attrs = {}
+        for attr_name in var_data.attrs:
+            if isinstance(var_data.attrs[attr_name], datetime):
+                # Metadata Attribute is a Datetime - we want to convert to Astropy Time
+                var_attrs[attr_name] = Time(var_data.attrs[attr_name])
+            else:
+                # Metadata Attribute loaded without modifications
+                var_attrs[attr_name] = var_data.attrs[attr_name]
+        return var_attrs
 
     def _load_data_variable(self, ts, var_name, var_data, var_attrs):
         # Create the Quantity object
@@ -212,7 +220,7 @@ class CDFHandler(HermesDataIOHandler):
             self._convert_global_attributes_to_cdf(data, cdf_file)
 
             # Add zAttributes
-            self._convert_variable_attributes_to_cdf(data, cdf_file)
+            self._convert_variables_to_cdf(data, cdf_file)
         return output_cdf_filepath
 
     def _convert_global_attributes_to_cdf(self, data, cdf_file):
@@ -222,32 +230,27 @@ class CDFHandler(HermesDataIOHandler):
             # We cannot add None Values to the CDF Global Attrs
             if attr_value is None:
                 cdf_file.attrs[attr_name] = ""
+            elif isinstance(attr_value, Time):
+                # Convert the Attribute to Datetime before adding to CDF File
+                cdf_file.attrs[attr_name] = attr_value.to_datetime()
             else:
                 # Add the Attribute to the CDF File
                 cdf_file.attrs[attr_name] = attr_value
 
-    def _convert_variable_attributes_to_cdf(self, data, cdf_file):
-        # Loop through Variable Attributes
+    def _convert_variables_to_cdf(self, data, cdf_file):
+        # Loop through Scalar TimeSeries Variables
         for var_name in data.timeseries.colnames:
             var_data = data.timeseries[var_name]
             if var_name == "time":
                 # Add 'time' in the TimeSeries as 'Epoch' within the CDF
                 cdf_file["Epoch"] = var_data.to_datetime()
                 # Add the Variable Attributes
-                for var_attr_name, var_attr_val in var_data.meta.items():
-                    cdf_file["Epoch"].attrs[var_attr_name] = var_attr_val
+                self._convert_variable_attributes_to_cdf("Epoch", var_data, cdf_file)
             else:
                 # Add the Variable to the CDF File
                 cdf_file[var_name] = var_data.value
                 # Add the Variable Attributes
-                for var_attr_name, var_attr_val in var_data.meta.items():
-                    if var_attr_val is None:
-                        raise ValueError(
-                            f"Variable {var_name}: Cannot Add vAttr: {var_attr_name}. Value was {str(var_attr_val)}"
-                        )
-                    else:
-                        # Add the Attribute to the CDF File
-                        cdf_file[var_name].attrs[var_attr_name] = var_attr_val
+                self._convert_variable_attributes_to_cdf(var_name, var_data, cdf_file)
 
         # Loop through Non-Record-Varying Data
         for var_name, var_data in data.support.items():
@@ -263,11 +266,17 @@ class CDFHandler(HermesDataIOHandler):
             )
 
             # Add the Variable Attributes
-            for var_attr_name, var_attr_val in var_data.meta.items():
-                if var_attr_val is None:
-                    raise ValueError(
-                        f"Variable {var_name}: Cannot Add vAttr: {var_attr_name}. Value was {str(var_attr_val)}"
-                    )
-                else:
-                    # Add the Attribute to the CDF File
-                    cdf_file[var_name].attrs[var_attr_name] = var_attr_val
+            self._convert_variable_attributes_to_cdf(var_name, var_data, cdf_file)
+
+    def _convert_variable_attributes_to_cdf(self, var_name, var_data, cdf_file):
+        for var_attr_name, var_attr_val in var_data.meta.items():
+            if var_attr_val is None:
+                raise ValueError(
+                    f"Variable {var_name}: Cannot Add vAttr: {var_attr_name}. Value was {str(var_attr_val)}"
+                )
+            elif isinstance(var_attr_val, Time):
+                # Convert the Attribute to Datetime before adding to CDF File
+                cdf_file[var_name].attrs[var_attr_name] = var_attr_val.to_datetime()
+            else:
+                # Add the Attribute to the CDF File
+                cdf_file[var_name].attrs[var_attr_name] = var_attr_val

--- a/hermes_core/util/tests/test_schema.py
+++ b/hermes_core/util/tests/test_schema.py
@@ -1,7 +1,5 @@
 import pytest
 import tempfile
-import yaml
-import datetime
 from collections import OrderedDict
 import numpy as np
 from numpy.random import random
@@ -166,9 +164,9 @@ def test_type_guessing():
         [1, 2, 3, 4],
         [[1.2, 1.3, 1.4], [2.2, 2.3, 2.4]],
         ["hello", "there", "everybody"],
-        datetime.datetime(2009, 1, 1),
-        datetime.datetime(2009, 1, 1, 12, 15, 12, 1000),
-        datetime.datetime(2009, 1, 1, 12, 15, 12, 1),
+        Time("2009-01-01T00:00:00.00", format="isot"),
+        Time("2009-01-01T12:15:12.1000", format="isot"),
+        Time("2009-01-01T12:15:12.1", format="isot"),
         [1.0],
         0.0,
         np.array([1, 2, 3], dtype=np.int32),
@@ -211,8 +209,8 @@ def test_type_guessing():
             1,
         ),
         ((3,), [const.CDF_CHAR, const.CDF_UCHAR], 9),
-        ((), [const.CDF_TIME_TT2000, const.CDF_EPOCH, const.CDF_EPOCH16], 1),
-        ((), [const.CDF_TIME_TT2000, const.CDF_EPOCH, const.CDF_EPOCH16], 1),
+        ((), [const.CDF_TIME_TT2000, const.CDF_EPOCH16, const.CDF_EPOCH], 1),
+        ((), [const.CDF_TIME_TT2000, const.CDF_EPOCH16, const.CDF_EPOCH], 1),
         ((), [const.CDF_TIME_TT2000, const.CDF_EPOCH16, const.CDF_EPOCH], 1),
         (
             (1,),
@@ -306,24 +304,24 @@ def test_min_max_TT2000():
     """Get min/max values for TT2000 types"""
     minval, maxval = HermesDataSchema()._get_minmax(const.CDF_TIME_TT2000)
     # Make sure the minimum isn't just plain invalid
-    assert minval == datetime.datetime(1900, 1, 1, 0, 0, 0, 0)
-    assert maxval == datetime.datetime(2250, 1, 1, 0, 0, 0, 0)
+    assert minval == Time("1900-1-1T00:00:00.000", format="isot")
+    assert maxval == Time("2250-1-1T00:00:00.000", format="isot")
 
 
 def test_min_max_Epoch16():
     """Get min/max values for Epoch16 types"""
     minval, maxval = HermesDataSchema()._get_minmax(const.CDF_EPOCH16)
     # Make sure the minimum isn't just plain invalid
-    assert minval == datetime.datetime(1900, 1, 1, 0, 0, 0, 0)
-    assert maxval == datetime.datetime(2250, 1, 1, 0, 0, 0, 0)
+    assert minval == Time("1900-1-1T00:00:00.000", format="isot")
+    assert maxval == Time("2250-1-1T00:00:00.000", format="isot")
 
 
 def test_min_max_Epoch():
     """Get min/max values for EPOCH types"""
     minval, maxval = HermesDataSchema()._get_minmax(const.CDF_EPOCH)
     # Make sure the minimum isn't just plain invalid
-    assert minval == datetime.datetime(1900, 1, 1, 0, 0, 0, 0)
-    assert maxval == datetime.datetime(2250, 1, 1, 0, 0, 0, 0)
+    assert minval == Time("1900-1-1T00:00:00.000", format="isot")
+    assert maxval == Time("2250-1-1T00:00:00.000", format="isot")
 
 
 def test_min_max_Float():


### PR DESCRIPTION
This PR converts use of the `datetime` library to use exclusively `astropy.time.Time` objects within the HERMES data container. `datetime` objects are still required for interactions with the `spacepy` library because spacepy does not have Astropy time support. However, this improves consistency within the data container itself so the `datetime` library is only used in the IO functionality needed to load and save CDFs with spacepy. 

closes #102