### PR TITLE
Version Pin Optional Dependencies in pyproject.toml, Lint with newest version of Black

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -31,8 +31,8 @@ jobs:
       run: |
         pip install pip setuptools wheel --upgrade
         # Install spacepy without build isolation to avoid issues with numpy
-        pip install numpy
-        pip install spacepy --no-build-isolation
+        pip install numpy==1.26.3
+        pip install spacepy==0.4.1 --no-build-isolation
         python -m pip install -e '.[style]'
     - name: Lint with Black
       run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,8 +31,8 @@ jobs:
       run: |
         pip install pip setuptools wheel --upgrade
         # Install spacepy without build isolation to avoid issues with numpy
-        pip install numpy
-        pip install spacepy --no-build-isolation
+        pip install numpy==1.26.3
+        pip install spacepy==0.4.1 --no-build-isolation
         pip install -e .[test]
       if: ${{ !(matrix.platform == 'windows-latest' && matrix.python-version == '3.11') }}
 

--- a/hermes_core/tests/test_util_util.py
+++ b/hermes_core/tests/test_util_util.py
@@ -1,4 +1,5 @@
 """Tests for util.py"""
+
 import pytest
 
 from astropy.time import Time

--- a/hermes_core/timedata.py
+++ b/hermes_core/timedata.py
@@ -334,9 +334,9 @@ class HermesData:
                     f"Instrument, {instr_name}, is not recognized. Must be one of {hermes_core.INST_NAMES}."
                 )
             # Set the Property
-            meta[
-                "Descriptor"
-            ] = f"{instr_name.upper()}>{hermes_core.INST_TO_FULLNAME[instr_name]}"
+            meta["Descriptor"] = (
+                f"{instr_name.upper()}>{hermes_core.INST_TO_FULLNAME[instr_name]}"
+            )
 
         # Check the Optional Data Level
         if data_level:

--- a/hermes_core/util/config.py
+++ b/hermes_core/util/config.py
@@ -4,6 +4,7 @@ This module provides configuration file functionality.
 This code is based on that provided by SunPy see
     licenses/SUNPY.rst
 """
+
 import os
 import shutil
 import configparser

--- a/hermes_core/util/exceptions.py
+++ b/hermes_core/util/exceptions.py
@@ -7,6 +7,7 @@ but rather in the particular package.
 This code is based on that provided by SunPy see
     licenses/SUNPY.rst
 """
+
 import warnings
 
 __all__ = [

--- a/hermes_core/util/io.py
+++ b/hermes_core/util/io.py
@@ -162,9 +162,9 @@ class CDFHandler(HermesDataIOHandler):
                                 )
                                 # Swap Units
                                 var_attrs["UNITS_DESC"] = var_attrs["UNITS"]
-                                var_attrs[
-                                    "UNITS"
-                                ] = u.dimensionless_unscaled.to_string()
+                                var_attrs["UNITS"] = (
+                                    u.dimensionless_unscaled.to_string()
+                                )
                                 self._load_spectra_variable(
                                     spectra, var_name, var_data, var_attrs, ts.time
                                 )
@@ -180,9 +180,9 @@ class CDFHandler(HermesDataIOHandler):
                                 )
                                 # Swap Units
                                 var_attrs["UNITS_DESC"] = var_attrs["UNITS"]
-                                var_attrs[
-                                    "UNITS"
-                                ] = u.dimensionless_unscaled.to_string()
+                                var_attrs["UNITS"] = (
+                                    u.dimensionless_unscaled.to_string()
+                                )
                                 self._load_timeseries_variable(
                                     ts, var_name, var_data, var_attrs
                                 )

--- a/hermes_core/util/schema.py
+++ b/hermes_core/util/schema.py
@@ -4,6 +4,7 @@ This module provides schema metadata derivations.
 This code is based on that provided by SpacePy see
     licenses/SPACEPY.rst
 """
+
 from pathlib import Path
 from collections import OrderedDict
 from copy import deepcopy
@@ -323,9 +324,9 @@ class HermesDataSchema:
 
         # Strip the Description of New Lines
         for attr_name in measurement_attribute_key.keys():
-            measurement_attribute_key[attr_name][
-                "description"
-            ] = measurement_attribute_key[attr_name]["description"].strip()
+            measurement_attribute_key[attr_name]["description"] = (
+                measurement_attribute_key[attr_name]["description"].strip()
+            )
 
         # Create New Column to describe which VAR_TYPE's require the given attribute
         for attr_name in measurement_attribute_key.keys():

--- a/hermes_core/util/tests/test_config.py
+++ b/hermes_core/util/tests/test_config.py
@@ -1,6 +1,7 @@
 """
 Tests for the config module
 """
+
 import io
 import os
 from pathlib import Path

--- a/hermes_core/util/tests/test_logger.py
+++ b/hermes_core/util/tests/test_logger.py
@@ -1,6 +1,7 @@
 """
 Tests for the logging module
 """
+
 import logging
 import os.path
 import warnings

--- a/hermes_core/util/util.py
+++ b/hermes_core/util/util.py
@@ -1,6 +1,7 @@
 """
 This module provides general utility functions.
 """
+
 import os
 
 from astropy.time import Time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,31 +38,31 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   'coverage>=5.0.3',
-  'pytest',
-  'pytest-astropy',
-  'pytest-cov',
-  'black',
-  'flake8',
-  'coverage[toml]'
+  'pytest==8.0.0',
+  'pytest-astropy==0.11.0',
+  'pytest-cov==4.1.0',
+  'black==24.1.1',
+  'flake8==7.0.0',
+  'coverage[toml]==7.4.1'
 ]
 
 docs = [
-  'sphinx',
-  'sphinx-automodapi',
-  'sphinx-copybutton'
+  'sphinx==7.2.6',
+  'sphinx-automodapi==0.16.0',
+  'sphinx-copybutton==0.5.2'
 ]
 
 test = [
-  'pytest',
-  'pytest-astropy',
-  'pytest-cov',
-  'coverage[toml]',
+  'pytest==8.0.0',
+  'pytest-astropy==0.11.0',
+  'pytest-cov==4.1.0',
+  'coverage[toml]==7.4.1'
 ]
 
 style = [
-  'black',
-  'flake8',
-  'rstcheck',
+  'black==24.1.1',
+  'flake8==7.0.0',
+  'rstcheck==6.2.0',
 ]
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
Description:

This PR pins the versions of the packages in the optional dependencies within the pyproject.toml file. It also performs a lint to make it compliant with the newest version of Black.