### PR TITLE
Updates to use Path rather than str

### DIFF
--- a/docs/examples/tutorial1.rst
+++ b/docs/examples/tutorial1.rst
@@ -7,6 +7,7 @@ This module provides an example for creating a CDF File using the `~hermes_core.
 class. This class is an abstraction of underlying data structures to make the handling of
 measurement data easier when reading and writing CDF data.
 
+    >>> from pathlib import Path
     >>> from collections import OrderedDict
     >>> import numpy as np
     >>> import astropy.units as u
@@ -140,7 +141,8 @@ measurement data easier when reading and writing CDF data.
     >>> DRYRUN=True
     >>> if DRYRUN:
     ...     with tempfile.TemporaryDirectory() as tmpdirname:
-    ...         cdf_file_path = example_data.save(output_path=tmpdirname)
+    ...         tmp_path = Path(tmpdirname)
+    ...         cdf_file_path = example_data.save(output_path=tmp_path)
     ... else:
     ...     cdf_file_path = example_data.save(output_path="./", overwrite=True)
 

--- a/docs/user-guide/reading_writing_data.rst
+++ b/docs/user-guide/reading_writing_data.rst
@@ -275,10 +275,12 @@ automatically generated as you might make the resulting CDF file non-compliant.
 Creating a ``HermesData`` from an existing CDF File
 ===================================================
 
-Given a current CDF File you can load it into a :py:class:`~hermes_core.timedata.HermesData` by providing a path to the CDF file::
+Given a current CDF File you can load it into a :py:class:`~hermes_core.timedata.HermesData` by providing a :py:class:`~pathlib.Path` to the CDF file::
 
+    >>> from pathlib import Path
     >>> from hermes_core.timedata import HermesData
-    >>> hermes_data = HermesData.load("hermes_eea_default_ql_20240406T120621_v0.0.1.cdf") # doctest: +SKIP
+    >>> data_path = Path("hermes_eea_default_ql_20240406T120621_v0.0.1.cdf")
+    >>> hermes_data = HermesData.load(data_path) # doctest: +SKIP
 
 The :py:class:`~hermes_core.timedata.HermesData` can the be updated, measurements added, metadata added, and written to a new CDF file.
 
@@ -492,10 +494,10 @@ Writing a CDF File
 ==================
 
 The :py:class:`~hermes_core.timedata.HermesData` class writes CDF files using the `~spacepy.pycdf` module.
-This can be done using the :py:func:`~hermes_core.timedata.HermesData.save` method which only requires a path to the folder where the CDF file should be saved.
+This can be done using the :py:func:`~hermes_core.timedata.HermesData.save` method which only requires a :py:class:`~pathlib.Path` to the folder where the CDF file should be saved.
 The filename is automatically derived consistent with HERMES file naming requirements.
 If no path is provided it writes the file to the current directory.
-This function returns the full path to the CDF file that was generated.
+This function returns the full :py:class:`~pathlib.Path` to the CDF file that was generated.
 From this you can validate and distribute your CDF file.
 
 Validating a CDF File
@@ -503,7 +505,7 @@ Validating a CDF File
 
 The :py:class:`~hermes_core.timedata.HermesData` uses the `~spacepy.pycdf.istp` module for CDF validation, in addition to custom
 tests for additional metadata. A CDF file can be validated using the :py:func:`~hermes_core.util.validation.validate` method
-and by passing, as a parameter, the full path to the CDF file to be validated::
+and by passing, as a parameter, the full :py:class:`~pathlib.Path` to the CDF file to be validated::
 
     >>> from hermes_core.util.validation import validate
     >>> validation_errors = validate(cdf_file_path) # doctest: +SKIP

--- a/hermes_core/tests/test_timedata.py
+++ b/hermes_core/tests/test_timedata.py
@@ -226,7 +226,8 @@ def test_none_attributes():
     with tempfile.TemporaryDirectory() as tmpdirname:
         with pytest.raises(ValueError):
             # Throws an error that we cannot have None attribute values
-            test_data.save(output_path=tmpdirname)
+            tmp_path = Path(tmpdirname)
+            test_data.save(output_path=tmp_path)
 
 
 def test_multidimensional_timeseries():
@@ -334,10 +335,10 @@ def test_hermes_data_valid_attrs():
 
     # Convert the Wrapper to a CDF File
     with tempfile.TemporaryDirectory() as tmpdirname:
-        test_file_output_path = test_data.save(output_path=tmpdirname)
-        test_file_cache_path = Path(test_file_output_path)
+        tmp_path = Path(tmpdirname)
+        test_file_output_path = test_data.save(output_path=tmp_path)
         # Test the File Exists
-        assert test_file_cache_path.exists()
+        assert test_file_output_path.exists()
 
 
 def test_global_attribute_template():
@@ -429,11 +430,10 @@ def test_hermes_data_single_measurement():
 
     # Convert the Wrapper to a CDF File
     with tempfile.TemporaryDirectory() as tmpdirname:
-        test_file_output_path = test_data.save(output_path=tmpdirname)
-
-        test_file_cache_path = Path(test_file_output_path)
+        tmp_path = Path(tmpdirname)
+        test_file_output_path = test_data.save(output_path=tmp_path)
         # Test the File Exists
-        assert test_file_cache_path.exists()
+        assert test_file_output_path.exists()
 
 
 def test_hermes_data_add_measurement():
@@ -777,16 +777,15 @@ def test_hermes_data_generate_valid_cdf():
 
     # Convert the Wrapper to a CDF File
     with tempfile.TemporaryDirectory() as tmpdirname:
-        # print out rights
-        test_file_output_path = test_data.save(output_path=tmpdirname, overwrite=True)
+        tmp_path = Path(tmpdirname)
+        test_file_output_path = test_data.save(output_path=tmp_path, overwrite=True)
 
         # Validate the generated CDF File
-        result = validate(filepath=test_file_output_path)
+        result = validate(file_path=test_file_output_path)
         assert len(result) <= 1  # Logical Source and File ID Do not Agree
 
         # Remove the File
-        test_file_cache_path = Path(test_file_output_path)
-        test_file_cache_path.unlink()
+        test_file_output_path.unlink()
 
 
 def test_hermes_data_from_cdf():
@@ -888,7 +887,8 @@ def test_hermes_data_from_cdf():
 
     # Convert the Wrapper to a CDF File
     with tempfile.TemporaryDirectory() as tmpdirname:
-        test_file_output_path = test_data.save(output_path=tmpdirname)
+        tmp_path = Path(tmpdirname)
+        test_file_output_path = test_data.save(output_path=tmp_path)
 
         # Validate the generated CDF File
         result = validate(test_file_output_path)
@@ -898,10 +898,10 @@ def test_hermes_data_from_cdf():
         new_writer = HermesData.load(test_file_output_path)
 
         # Remove the Original File
-        test_file_cache_path = Path(test_file_output_path)
+        test_file_cache_path = test_file_output_path
         test_file_cache_path.unlink()
 
-        test_file_output_path2 = new_writer.save(output_path=tmpdirname)
+        test_file_output_path2 = new_writer.save(output_path=tmp_path)
         assert test_file_output_path == test_file_output_path2
 
         # Validate the generated CDF File
@@ -976,7 +976,8 @@ def test_hermes_data_idempotency():
     )
 
     with tempfile.TemporaryDirectory() as tmpdirname:
-        test_file_output_path = test_data.save(output_path=tmpdirname)
+        tmp_path = Path(tmpdirname)
+        test_file_output_path = test_data.save(output_path=tmp_path)
 
         # Try loading the *Invalid* CDF File
         loaded_data = HermesData.load(test_file_output_path)
@@ -1091,11 +1092,10 @@ def test_bitlength_save_cdf(bitlength):
     hermes_data = HermesData(timeseries=ts, meta=input_attrs)
     hermes_data.timeseries["Bx"].meta.update({"CATDESC": "Test"})
     with tempfile.TemporaryDirectory() as tmpdirname:
-        test_file_output_path = hermes_data.save(output_path=tmpdirname)
-
-        test_file_cache_path = Path(test_file_output_path)
+        tmp_path = Path(tmpdirname)
+        test_file_output_path = hermes_data.save(output_path=tmp_path)
         # Test the File Exists
-        assert test_file_cache_path.exists()
+        assert test_file_output_path.exists()
 
 
 def test_overwrite_save():
@@ -1139,15 +1139,16 @@ def test_overwrite_save():
     td = get_test_hermes_data()
     td.meta.update(input_attrs)
     with tempfile.TemporaryDirectory() as tmpdirname:
-        test_file_output_path = Path(td.save(output_path=tmpdirname))
+        tmp_path = Path(tmpdirname)
+        test_file_output_path = td.save(output_path=tmp_path)
         # Test the File Exists
         assert test_file_output_path.exists()
         # without overwrite set trying to create the file again should lead to an error
         with pytest.raises(CDFError):
-            test_file_output_path = td.save(output_path=tmpdirname, overwrite=False)
+            test_file_output_path = td.save(output_path=tmp_path, overwrite=False)
 
         # with overwrite set there should be no error
-        assert Path(td.save(output_path=tmpdirname, overwrite=True)).exists()
+        assert td.save(output_path=tmp_path, overwrite=True).exists()
 
 
 def test_without_cdf_lib():

--- a/hermes_core/timedata.py
+++ b/hermes_core/timedata.py
@@ -788,40 +788,40 @@ class HermesData:
         # Re-Derive Metadata
         self._derive_metadata()
 
-    def save(self, output_path: str = None, overwrite: bool = False):
+    def save(self, output_path: Path = None, overwrite: bool = False):
         """
         Save the data to a HERMES CDF file.
 
         Parameters
         ----------
-        output_path : `str`, optional
-            A string path to the directory where file is to be saved.
+        output_path : `pathlib.Path`, optional
+            A fully specified path to the directory where the file is to be saved.
             If not provided, saves to the current directory.
         overwrite : `bool`
             If set, overwrites existing file of the same name.
         Returns
         -------
-        path : `str`
+        path : `pathlib.Path`
             A path to the saved file.
         """
         handler = CDFHandler()
         if not output_path:
-            output_path = str(Path.cwd())
+            output_path = Path.cwd()
         if overwrite:
-            cdf_file_path = Path(output_path) / (self.meta["Logical_file_id"] + ".cdf")
+            cdf_file_path = output_path / (self.meta["Logical_file_id"] + ".cdf")
             if cdf_file_path.exists():
                 cdf_file_path.unlink()
         return handler.save_data(data=self, file_path=output_path)
 
     @classmethod
-    def load(cls, file_path: str):
+    def load(cls, file_path: Path):
         """
         Load data from a file.
 
         Parameters
         ----------
-        file_path : `str`
-            A fully specificed file path.
+        file_path : `pathlib.Path`
+            A fully specified file path of the data file to load.
 
         Returns
         -------
@@ -834,7 +834,7 @@ class HermesData:
 
         """
         # Determine the file type
-        file_extension = Path(file_path).suffix
+        file_extension = file_path.suffix
 
         # Create the appropriate handler object based on file type
         if file_extension == ".cdf":

--- a/hermes_core/util/io.py
+++ b/hermes_core/util/io.py
@@ -26,14 +26,14 @@ class HermesDataIOHandler(ABC):
     """
 
     @abstractmethod
-    def load_data(self, file_path: str) -> Tuple[TimeSeries, dict]:
+    def load_data(self, file_path: Path) -> Tuple[TimeSeries, dict]:
         """
         Load data from a file.
 
         Parameters
         ----------
-        file_path : `str`
-            A fully specified file path.
+        file_path : `pathlib.Path`
+            A fully specified file path of the data file to load.
 
         Returns
         -------
@@ -47,7 +47,7 @@ class HermesDataIOHandler(ABC):
         pass
 
     @abstractmethod
-    def save_data(self, data, file_path: str):
+    def save_data(self, data, file_path: Path):
         """
         Save data to a file.
 
@@ -55,8 +55,8 @@ class HermesDataIOHandler(ABC):
         ----------
         data : `hermes_core.timedata.HermesData`
             An instance of `HermesData` containing the data to be saved.
-        file_path : `str`
-            The fully specified file path to save into.
+        file_path : `pathlib.Path`
+            A fully specified path to the directory where the file is to be saved.
         """
         pass
 
@@ -79,14 +79,14 @@ class CDFHandler(HermesDataIOHandler):
         # CDF Schema
         self.schema = HermesDataSchema()
 
-    def load_data(self, file_path: str) -> Tuple[TimeSeries, dict]:
+    def load_data(self, file_path: Path) -> Tuple[TimeSeries, dict]:
         """
         Load heliophysics data from a CDF file.
 
         Parameters
         ----------
-        file_path : `str`
-            The path to the CDF file.
+        file_path : `pathlib.Path`
+            A fully specified file path to the CDF file to load.
 
         Returns
         -------
@@ -99,7 +99,7 @@ class CDFHandler(HermesDataIOHandler):
         """
         from spacepy.pycdf import CDF
 
-        if not Path(file_path).exists():
+        if not file_path.exists():
             raise FileNotFoundError(f"CDF Could not be loaded from path: {file_path}")
 
         # Create a new TimeSeries
@@ -110,7 +110,7 @@ class CDFHandler(HermesDataIOHandler):
         spectra = []
 
         # Open CDF file with context manager
-        with CDF(file_path) as input_file:
+        with CDF(str(file_path)) as input_file:
             # Add Global Attributes from the CDF file to TimeSeries
             input_global_attrs = {}
             for attr_name in input_file.attrs:
@@ -309,7 +309,7 @@ class CDFHandler(HermesDataIOHandler):
         # Add to Spectra
         spectra.append((var_name, var_cube))
 
-    def save_data(self, data, file_path: str):
+    def save_data(self, data, file_path: Path):
         """
         Save heliophysics data to a CDF file.
 
@@ -317,12 +317,12 @@ class CDFHandler(HermesDataIOHandler):
         ----------
         data : `hermes_core.timedata.HermesData`
             An instance of `HermesData` containing the data to be saved.
-        file_path : `str`
-            The path to save the CDF file.
+        file_path : `pathlib.Path`
+            A fully specified path to the directory where the CDF file is to be saved.
 
         Returns
         -------
-        path : `str`
+        path : `pathlib.Path`
             A path to the saved file.
         """
         from spacepy.pycdf import CDF
@@ -336,7 +336,7 @@ class CDFHandler(HermesDataIOHandler):
 
             # Add zAttributes
             self._convert_variables_to_cdf(data, cdf_file)
-        return output_cdf_filepath
+        return Path(output_cdf_filepath)
 
     def _convert_global_attributes_to_cdf(self, data, cdf_file):
         # Loop though Global Attributes in target_dict

--- a/hermes_core/util/tests/test_io.py
+++ b/hermes_core/util/tests/test_io.py
@@ -98,9 +98,10 @@ def test_cdf_io():
 def test_cdf_bad_file_path():
     """Test Loading CDF from a non-existant file"""
     with tempfile.TemporaryDirectory() as tmpdirname:
+        tmp_path = Path(tmpdirname)
         # Try loading from non-existant_path
         with pytest.raises(FileNotFoundError):
-            _ = HermesData.load(tmpdirname + "non_existant_file.cdf")
+            _ = HermesData.load(tmp_path / "non_existant_file.cdf")
 
 
 def test_cdf_nrv_support_data():
@@ -111,11 +112,12 @@ def test_cdf_nrv_support_data():
     td = get_test_hermes_data()
 
     with tempfile.TemporaryDirectory() as tmpdirname:
+        tmp_path = Path(tmpdirname)
         # Convert HermesData the to a CDF File
-        test_file_output_path = td.save(output_path=tmpdirname)
+        test_file_output_path = td.save(output_path=tmp_path)
 
         # Load the JSON file as JSON
-        with CDF(test_file_output_path, readonly=False) as cdf_file:
+        with CDF(str(test_file_output_path), readonly=False) as cdf_file:
             # Add Non-Record-Varying Variable
             cdf_file["Test_NRV_Var"] = [1, 2, 3]
 
@@ -138,11 +140,12 @@ def test_cdf_spectra_data():
     td = get_test_hermes_data()
 
     with tempfile.TemporaryDirectory() as tmpdirname:
+        tmp_path = Path(tmpdirname)
         # Convert HermesData the to a CDF File
-        test_file_output_path = td.save(output_path=tmpdirname)
+        test_file_output_path = td.save(output_path=tmp_path)
 
         # Load the JSON file as JSON
-        with CDF(test_file_output_path, readonly=False) as cdf_file:
+        with CDF(str(test_file_output_path), readonly=False) as cdf_file:
             # Add Spectra Data Variable
             cdf_file["Test_Spectra_Var"] = np.random.random(size=(10, 10))
             cdf_file["Test_Spectra_Var"].meta["UNITS"] = "counts"

--- a/hermes_core/util/tests/test_validation.py
+++ b/hermes_core/util/tests/test_validation.py
@@ -41,14 +41,14 @@ def get_test_timeseries():
 
 def test_non_cdf_file():
     """Function to Test a file using the CDFValidator that is not a CDF File"""
-    invlid_path = str(Path(hermes_core.__file__).parent / "data" / "README.rst")
+    invlid_path = Path(hermes_core.__file__).parent / "data" / "README.rst"
     with pytest.raises(ValueError):
         _ = validate(invlid_path)
 
 
 def test_non_existant_file():
     """Function to Test a file using the CDFValidator that does not exist"""
-    invlid_path = str(Path(hermes_core.__file__).parent / "data" / "test.cdf")
+    invlid_path = Path(hermes_core.__file__).parent / "data" / "test.cdf"
     result = validate(invlid_path)
     assert len(result) == 1
     assert "Could not open CDF File at path:" in result[0]
@@ -64,9 +64,10 @@ def test_missing_global_attrs():
 
     # Convert to a CDF File and Validate
     with tempfile.TemporaryDirectory() as tmpdirname:
-        out_file = td.save(tmpdirname)
+        tmp_path = Path(tmpdirname)
+        out_file = td.save(tmp_path)
 
-        with CDF(out_file, readonly=False) as cdf:
+        with CDF(str(out_file), readonly=False) as cdf:
             del cdf.meta["Descriptor"]
 
         # Validate
@@ -88,9 +89,10 @@ def test_missing_var_type():
 
     # Convert to a CDF File and Validate
     with tempfile.TemporaryDirectory() as tmpdirname:
-        out_file = td.save(tmpdirname)
+        tmp_path = Path(tmpdirname)
+        out_file = td.save(tmp_path)
 
-        with CDF(out_file, readonly=False) as cdf:
+        with CDF(str(out_file), readonly=False) as cdf:
             del cdf["measurement"].meta["VAR_TYPE"]
 
         # Validate
@@ -111,9 +113,10 @@ def test_missing_variable_attrs():
 
     # Convert to a CDF File and Validate
     with tempfile.TemporaryDirectory() as tmpdirname:
-        out_file = td.save(tmpdirname)
+        tmp_path = Path(tmpdirname)
+        out_file = td.save(tmp_path)
 
-        with CDF(out_file, readonly=False) as cdf:
+        with CDF(str(out_file), readonly=False) as cdf:
             del cdf["measurement"].meta["CATDESC"]
             del cdf["measurement"].meta["UNITS"]
             cdf["measurement"].meta["DISPLAY_TYPE"] = "bad_type"

--- a/hermes_core/util/validation.py
+++ b/hermes_core/util/validation.py
@@ -9,14 +9,14 @@ from hermes_core.util.schema import HermesDataSchema
 __all__ = ["validate", "CDFValidator"]
 
 
-def validate(filepath: str) -> list[str]:
+def validate(file_path: Path) -> list[str]:
     """
     Validate a data file such as a CDF.
 
     Parameters
     ----------
-    filepath : `str`
-        A fully specificed file path.
+    file_path : `pathlib.Path`
+        A fully specified file path of the data file to validate.
 
     Returns
     -------
@@ -24,7 +24,7 @@ def validate(filepath: str) -> list[str]:
         A list of validation errors returned. A valid file will result in an emppty list being returned.
     """
     # Determine the file type
-    file_extension = Path(filepath).suffix
+    file_extension = file_path.suffix
 
     # Create the appropriate validator object based on file type
     if file_extension == ".cdf":
@@ -33,7 +33,7 @@ def validate(filepath: str) -> list[str]:
         raise ValueError(f"Unsupported file type: {file_extension}")
 
     # Call the validate method of the validator object
-    return validator.validate(filepath)
+    return validator.validate(file_path)
 
 
 class HermesDataValidator(ABC):
@@ -42,14 +42,14 @@ class HermesDataValidator(ABC):
     """
 
     @abstractmethod
-    def validate(self, file_path: str) -> list[str]:
+    def validate(self, file_path: Path) -> list[str]:
         """
         Validate the heliophysics data file.
 
         Parameters
         ----------
-        file_path : `str`
-            The path to the data file.
+        file_path : `pathlib.Path`
+            A fully specified file path of the data file to validate.
 
         Returns
         -------
@@ -70,14 +70,14 @@ class CDFValidator(HermesDataValidator):
         # CDF Schema
         self.schema = HermesDataSchema()
 
-    def validate(self, file_path: str) -> list[str]:
+    def validate(self, file_path: Path) -> list[str]:
         """
         Validate the CDF file.
 
         Parameters
         ----------
-        file_path : `str`
-            The path to the CDF file.
+        file_path : `pathlib.Path`
+            A fully specified file path of the CDF data file to validate.
 
         Returns
         -------
@@ -89,7 +89,7 @@ class CDFValidator(HermesDataValidator):
 
         try:
             # Open CDF file with context manager
-            with CDF(file_path, readonly=True) as cdf_file:
+            with CDF(str(file_path), readonly=True) as cdf_file:
                 # Verify that all `required` global attributes in the schema are present
                 global_attr_validation_errors = self._validate_global_attr_schema(
                     cdf_file=cdf_file


### PR DESCRIPTION
This PR updates the HERMES Core functionality to consistently use `pathlib.Path` objects for file paths when loading, saving, and validating CDF files. Previously these functions used `str` objects, which goes against the HERMES best-practices. This PR aligns the functionality of the package with the best practices defined for the mission code development. 

This PR and https://github.com/HERMES-SOC/hermes_eea/pull/41 are co-dependent so we need to decide which we want to complete first. My recommendation would be to complete this PR first.

I've manually tested the sdc_aws_processing_lambda, combining changes from both PRs , and successfully generated a CDF file.