### PR TITLE
Update Output Path Requirements

### DIFF
--- a/hermes_core/timedata.py
+++ b/hermes_core/timedata.py
@@ -947,25 +947,32 @@ class HermesData:
         Parameters
         ----------
         output_path : `pathlib.Path`, optional
-            A fully specified path to the directory where the file is to be saved.
-            If not provided, saves to the current directory.
+            This can take two forms:
+
+            1. A fully specified path to the directory where the file is to be saved. This will save the file with the default name of the Logical_file_id metadata attribute. This is the recommended apprach to saving files.
+
+            2. A fully specified path to the file to be saved, including the file name. This will ignore the Logical_file_id metadata attribute and save the file with the provided name. This is not the reccomended approach, although it can be used for local development and testing.
+
+            If not provided, saves to the current directory, using the file name of the Logical_file_id metadata attribute.
         overwrite : `bool`
-            If set, overwrites existing file of the same name.
+            If set, overwrites existing file of the same name. This parameter should be used for development and testing purposes only. This parameter should not be set to `True` when saving data for archiving as a part of the production data processing pipeline.
+        
         Returns
         -------
         path : `pathlib.Path`
             A path to the saved file.
+            
+        Raises
+        ------
+        FileNotFoundError: If the output_path points to a directory that does not exist.
+        ValueError: If the output_path is a file and does not have a recognized extension.
         """
         from hermes_core.util.io import CDFHandler
 
         handler = CDFHandler()
         if not output_path:
             output_path = Path.cwd()
-        if overwrite:
-            cdf_file_path = output_path / (self.meta["Logical_file_id"] + ".cdf")
-            if cdf_file_path.exists():
-                cdf_file_path.unlink()
-        return handler.save_data(data=self, file_path=output_path)
+        return handler.save_data(data=self, file_path=output_path, overwrite=overwrite)
 
     @classmethod
     def load(cls, file_path: Path):

--- a/hermes_core/timedata.py
+++ b/hermes_core/timedata.py
@@ -949,19 +949,19 @@ class HermesData:
         output_path : `pathlib.Path`, optional
             This can take two forms:
 
-            1. A fully specified path to the directory where the file is to be saved. This will save the file with the default name of the Logical_file_id metadata attribute. This is the recommended apprach to saving files.
+            1. A fully specified path to the directory where the file is to be saved. This will save the file with the default name of the Logical_file_id metadata attribute. This is the recommended approach to saving files.
 
-            2. A fully specified path to the file to be saved, including the file name. This will ignore the Logical_file_id metadata attribute and save the file with the provided name. This is not the reccomended approach, although it can be used for local development and testing.
+            2. A fully specified path to the file to be saved, including the file name. This will ignore the Logical_file_id metadata attribute and save the file with the provided name. This is not the recommended approach, although it can be used for local development and testing.
 
             If not provided, saves to the current directory, using the file name of the Logical_file_id metadata attribute.
         overwrite : `bool`
             If set, overwrites existing file of the same name. This parameter should be used for development and testing purposes only. This parameter should not be set to `True` when saving data for archiving as a part of the production data processing pipeline.
-        
+
         Returns
         -------
         path : `pathlib.Path`
             A path to the saved file.
-            
+
         Raises
         ------
         FileNotFoundError: If the output_path points to a directory that does not exist.

--- a/hermes_core/util/io.py
+++ b/hermes_core/util/io.py
@@ -53,6 +53,10 @@ class HermesDataIOHandler(ABC):
     @abstractmethod
     def save_data(self, data, file_path: Path, overwrite: bool = False):
         """
+        Save data to a file.
+
+        Parameters
+        ----------
         data : `hermes_core.timedata.HermesData`
             An instance of `HermesData` containing the data to be saved.
         file_path : `pathlib.Path`

--- a/hermes_core/util/io.py
+++ b/hermes_core/util/io.py
@@ -58,9 +58,9 @@ class HermesDataIOHandler(ABC):
         file_path : `pathlib.Path`
             This can take two forms:
 
-            1. A fully specified path to the directory where the file is to be saved. This will save the file with the default name of the Logical_file_id metadata attribute. This is the recommended apprach to saving files.
+            1. A fully specified path to the directory where the file is to be saved. This will save the file with the default name of the Logical_file_id metadata attribute. This is the recommended approach to saving files.
 
-            2. A fully specified path to the file to be saved, including the file name. This will ignore the Logical_file_id metadata attribute and save the file with the provided name. This is not the reccomended approach, although it can be used for local development and testing.
+            2. A fully specified path to the file to be saved, including the file name. This will ignore the Logical_file_id metadata attribute and save the file with the provided name. This is not the recommended approach, although it can be used for local development and testing.
         overwrite : `bool`
             If set, overwrites existing file of the same name. This parameter should be used for development and testing purposes only. This parameter should not be set to `True` when saving data for archiving as a part of the production data processing pipeline.
 
@@ -354,9 +354,9 @@ class CDFHandler(HermesDataIOHandler):
         file_path : `pathlib.Path`
             This can take two forms:
 
-            1. A fully specified path to the directory where the file is to be saved. This will save the file with the default name of the Logical_file_id metadata attribute. This is the recommended apprach to saving files.
+            1. A fully specified path to the directory where the file is to be saved. This will save the file with the default name of the Logical_file_id metadata attribute. This is the recommended approach to saving files.
 
-            2. A fully specified path to the file to be saved, including the file name. This will ignore the Logical_file_id metadata attribute and save the file with the provided name. This is not the reccomended approach, although it can be used for local development and testing.
+            2. A fully specified path to the file to be saved, including the file name. This will ignore the Logical_file_id metadata attribute and save the file with the provided name. This is not the recommended approach, although it can be used for local development and testing.
         overwrite : `bool`
             If set, overwrites existing file of the same name. This parameter should be used for development and testing purposes only. This parameter should not be set to `True` when saving data for archiving as a part of the production data processing pipeline.
 

--- a/hermes_core/util/tests/test_io.py
+++ b/hermes_core/util/tests/test_io.py
@@ -109,6 +109,35 @@ def test_cdf_bad_file_path():
             _ = HermesData.load(tmp_path / "non_existant_file.cdf")
 
 
+def test_cdf_save():
+    """Functions to test all the parameters of saving a CDF file"""
+    td = get_test_hermes_data()
+
+    # Save to a File that is not a CDF
+    with pytest.raises(ValueError):
+        td.save(output_path=Path("test_file.txt"))
+
+    # Save to a File that's Parent Directory does not exist
+    with pytest.raises(FileNotFoundError):
+        td.save(output_path=Path("non_existant_directory/test_file.cdf"))
+
+    # Save to a File that's parent Directory does exist
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        test_file_output_path = td.save(output_path=Path(tmpdirname) / "test_file.cdf")
+        assert test_file_output_path.is_file()
+        assert test_file_output_path.name == "test_file.cdf"
+
+    # Save to a Diectory that does not exist
+    with pytest.raises(FileNotFoundError):
+        td.save(output_path=Path("./non_existant_directory"))
+
+    # Save to a Directory that does exist
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        test_file_output_path = td.save(output_path=Path(tmpdirname))
+        assert test_file_output_path.is_file()
+        assert test_file_output_path.name == f"{td.meta['Logical_file_id']}.cdf"
+
+
 def test_cdf_nrv_support_data():
     """
     Test Loading Non-Record-Varying data with CDF IO Handler

--- a/hermes_core/util/tests/test_io.py
+++ b/hermes_core/util/tests/test_io.py
@@ -87,8 +87,9 @@ def test_cdf_io():
     td = get_test_hermes_data()
 
     with tempfile.TemporaryDirectory() as tmpdirname:
+        tmp_path = Path(tmpdirname)
         # Convert HermesData the to a CDF File
-        test_file_output_path = td.save(output_path=tmpdirname)
+        test_file_output_path = td.save(output_path=tmp_path)
 
         # Load the CDF to a HermesData Object
         td_loaded = HermesData.load(test_file_output_path)
@@ -97,7 +98,7 @@ def test_cdf_io():
         assert len(td.timeseries.columns) == len(td_loaded.timeseries.columns)
 
         with pytest.raises(CDFError):
-            td_loaded.save(output_path=tmpdirname)
+            td_loaded.save(output_path=tmp_path)
 
 
 def test_cdf_bad_file_path():


### PR DESCRIPTION
This PR relaxes the requirements that the `HermesData.save(output_path)` must take a `Path` to a directory. 

The `output_path` can be either:

1. A fully specified path to the directory where the file is to be saved. This will save the file with the default name of the Logical_file_id metadata attribute. This is the recommended approach to saving files. 
    - (This maintains the existing functionality)
2. A fully specified path to the file to be saved, including the file name. This will ignore the Logical_file_id metadata attribute and save the file with the provided name. This is not the recommended approach, although it can be used for local development and test
    - This is the newly added functionality 

No changes have been made that impact the `overwrite` parameter of this function.  