### PR TITLE
Update Calibration Workflow

### DIFF
--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -23,7 +23,7 @@ jobs:
         
     - name: Run Lambda Docker Container
       run: |
-        docker run -d -p 9000:8080 -e USE_INSTRUMENT_TEST_DATA=True processing_function:latest
+        docker run -d -p 9000:8080 -e USE_INSTRUMENT_TEST_DATA=True -e SWXSOC_MISSION=hermes processing_function:latest
         container_id=$(docker ps -qf "ancestor=processing_function:latest")
         echo "Container ID: $container_id"
 

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,6 @@
 Overview
 ========
 
-Test Changes. 
-
 .. start-badges
 
 .. list-table::

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,8 @@
 Overview
 ========
 
+Test Changes. 
+
 .. start-badges
 
 .. list-table::


### PR DESCRIPTION
This PR updates the calibration workflow to add a `SWXSOC_MISSION` environment variable when running the processing container. This environment variable is used when parsing the `swxsoc` config and defines what mission's config is loaded. Now that we have multiple mission's configs in the `swxsoc` config, we need to add the environment variable to the container to specify that HERMES files are being processed. 

The calibration workflow will fail on this PR since the workflow is set to run `on: [pull_request_target]` (the main branch). However, it is tested locally by myself and Damian. 