### PR TITLE
Fix Dependency Resolution by Adding .git to swxsoc URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
 ]
 dependencies = [
-  'swxsoc @ git+https://github.com/swxsoc/swxsoc@main',
+  'swxsoc @ git+https://github.com/swxsoc/swxsoc.git@main',
   'astropy>=5.3.3',
   'numpy>=1.18.0',
   'sunpy>=5.0.1',


### PR DESCRIPTION
This PR resolves a dependency conflict caused by multiple packages depending on swxsoc. The issue arose because swxsoc was referenced without .git in the dependency URL, leading to conflicts during installation when resolving packages like padre-meddea and hermes-core, both of which depend on swxsoc.

By explicitly adding .git to the swxsoc URL (i.e., git+https://github.com/swxsoc/swxsoc.git@main), we ensure pip properly identifies and resolves the dependency. This change also aligns with pip's expected URL format for Git dependencies.